### PR TITLE
Multi-dimensional support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+xskillscore.egg-info/

--- a/README.rst
+++ b/README.rst
@@ -53,3 +53,6 @@ Examples
    mse = xs.mse(obs, fct, 'time')
 
    mae = xs.mae(obs, fct, 'time') 
+   
+   # You can also specify multiple axes
+   r = xs.pearson_r(obs, fct, ['lat', 'lon'])

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -6,6 +6,13 @@ from.np_deterministic import _pearson_r, _pearson_r_p_value, _rmse, _mse, _mae
 __all__ = ['pearson_r', 'pearson_r_p_value', 'rmse', 'mse', 'mae']
 
 
+def _preprocess(dim):
+    if isinstance(dim, str):
+        dim = [dim]
+    axis = tuple(range(-1, -len(dim) - 1, -1))
+    return dim, axis
+
+
 def pearson_r(a, b, dim):
     """
     Pearson's correlation coefficient.
@@ -16,8 +23,8 @@ def pearson_r(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
         Mix of labeled and/or unlabeled arrays to which to apply the function.
-    dim : str
-        The dimension to apply the correlation along.
+    dim : str, list
+        The dimension(s) to apply the correlation along.
 
     Returns
     -------
@@ -31,9 +38,11 @@ def pearson_r(a, b, dim):
     xarray.apply_ufunc
 
     """
+    dim, axis = _preprocess(dim)
+
     return xr.apply_ufunc(_pearson_r, a, b,
-                          input_core_dims=[[dim], [dim]],
-                          kwargs={'axis': -1},
+                          input_core_dims=[dim, dim],
+                          kwargs={'axis': axis},
                           dask='parallelized',
                           output_dtypes=[float])
 
@@ -48,8 +57,8 @@ def pearson_r_p_value(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
         Mix of labeled and/or unlabeled arrays to which to apply the function.
-    dim : str
-        The dimension to apply the correlation along.
+    dim : str, list
+        The dimension(s) to apply the correlation along.
 
     Returns
     -------
@@ -63,9 +72,11 @@ def pearson_r_p_value(a, b, dim):
     xarray.apply_ufunc
 
     """
+    dim, axis = _preprocess(dim)
+
     return xr.apply_ufunc(_pearson_r_p_value, a, b,
-                          input_core_dims=[[dim], [dim]],
-                          kwargs={'axis': -1},
+                          input_core_dims=[dim, dim],
+                          kwargs={'axis': axis},
                           dask='parallelized',
                           output_dtypes=[float])
 
@@ -80,8 +91,8 @@ def rmse(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
         Mix of labeled and/or unlabeled arrays to which to apply the function.
-    dim : str
-        The dimension to apply the correlation along.
+    dim : str, list
+        The dimension(s) to apply the rmse along.
 
     Returns
     -------
@@ -95,9 +106,11 @@ def rmse(a, b, dim):
     xarray.apply_ufunc
 
     """
+    dim, axis = _preprocess(dim)
+
     return xr.apply_ufunc(_rmse, a, b,
-                          input_core_dims=[[dim], [dim]],
-                          kwargs={'axis': -1},
+                          input_core_dims=[dim, dim],
+                          kwargs={'axis': axis},
                           dask='parallelized',
                           output_dtypes=[float])
 
@@ -112,8 +125,8 @@ def mse(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
         Mix of labeled and/or unlabeled arrays to which to apply the function.
-    dim : str
-        The dimension to apply the correlation along.
+    dim : str, list
+        The dimension(s) to apply the mse along.
 
     Returns
     -------
@@ -127,9 +140,11 @@ def mse(a, b, dim):
     xarray.apply_ufunc
 
     """
+    dim, axis = _preprocess(dim)
+
     return xr.apply_ufunc(_mse, a, b,
-                          input_core_dims=[[dim], [dim]],
-                          kwargs={'axis': -1},
+                          input_core_dims=[dim, dim],
+                          kwargs={'axis': axis},
                           dask='parallelized',
                           output_dtypes=[float])
 
@@ -144,8 +159,8 @@ def mae(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
         Mix of labeled and/or unlabeled arrays to which to apply the function.
-    dim : str
-        The dimension to apply the correlation along.
+    dim : str, list
+        The dimension(s) to apply the mae along.
 
     Returns
     -------
@@ -159,8 +174,10 @@ def mae(a, b, dim):
     xarray.apply_ufunc
 
     """
+    dim, axis = _preprocess(dim)
+
     return xr.apply_ufunc(_mae, a, b,
-                          input_core_dims=[[dim], [dim]],
-                          kwargs={'axis': -1},
+                          input_core_dims=[dim, dim],
+                          kwargs={'axis': axis},
                           dask='parallelized',
                           output_dtypes=[float])

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -38,11 +38,17 @@ def pearson_r(a, b, dim):
     xarray.apply_ufunc
 
     """
-    dim, axis = _preprocess(dim)
+    dim, _ = _preprocess(dim)
+    if len(dim) > 1:
+        new_dim = '_'.join(dim)
+        a = a.stack(**{new_dim: dim})
+        b = b.stack(**{new_dim: dim})
+    else:
+        new_dim = dim[0]
 
     return xr.apply_ufunc(_pearson_r, a, b,
-                          input_core_dims=[dim, dim],
-                          kwargs={'axis': axis},
+                          input_core_dims=[[new_dim], [new_dim]],
+                          kwargs={'axis': -1},
                           dask='parallelized',
                           output_dtypes=[float])
 
@@ -72,11 +78,17 @@ def pearson_r_p_value(a, b, dim):
     xarray.apply_ufunc
 
     """
-    dim, axis = _preprocess(dim)
+    dim, _ = _preprocess(dim)
+    if len(dim) > 1:
+        new_dim = '_'.join(dim)
+        a = a.stack(**{new_dim: dim})
+        b = b.stack(**{new_dim: dim})
+    else:
+        new_dim = dim[0]
 
     return xr.apply_ufunc(_pearson_r_p_value, a, b,
-                          input_core_dims=[dim, dim],
-                          kwargs={'axis': axis},
+                          input_core_dims=[[new_dim], [new_dim]],
+                          kwargs={'axis': -1},
                           dask='parallelized',
                           output_dtypes=[float])
 

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -28,11 +28,13 @@ def _pearson_r(a, b, axis):
     scipy.stats.pearsonr
 
     """
-    ma = np.mean(a, axis=axis)
-    mb = np.mean(b, axis=axis)
+    a = np.rollaxis(a, axis)
+    b = np.rollaxis(b, axis)
+    ma = np.mean(a, axis=0)
+    mb = np.mean(b, axis=0)
     am, bm = a - ma, b - mb
-    r_num = np.sum(am * bm, axis=axis)
-    r_den = np.sqrt(np.sum(am*am, axis=axis) * np.sum(bm*bm, axis=axis))
+    r_num = np.sum(am * bm, axis=0)
+    r_den = np.sqrt(np.sum(am*am, axis=0) * np.sum(bm*bm, axis=0))
     r = r_num / r_den
     res = np.clip(r, -1.0, 1.0)
     return res
@@ -62,6 +64,7 @@ def _pearson_r_p_value(a, b, axis):
 
     """
     r = _pearson_r(a, b, axis)
+    a = np.rollaxis(a, axis)
     df = a.shape[0] - 2
     t_squared = r**2 * (df / ((1.0 - r) * (1.0 + r)))
     _x = df/(df+t_squared)

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -28,13 +28,11 @@ def _pearson_r(a, b, axis):
     scipy.stats.pearsonr
 
     """
-    a = np.rollaxis(a, axis)
-    b = np.rollaxis(b, axis)
-    ma = np.mean(a, axis=0)
-    mb = np.mean(b, axis=0)
+    ma = np.mean(a, axis=axis)
+    mb = np.mean(b, axis=axis)
     am, bm = a - ma, b - mb
-    r_num = np.sum(am * bm, axis=0)
-    r_den = np.sqrt(np.sum(am*am, axis=0) * np.sum(bm*bm, axis=0))
+    r_num = np.sum(am * bm, axis=axis)
+    r_den = np.sqrt(np.sum(am*am, axis=axis) * np.sum(bm*bm, axis=axis))
     r = r_num / r_den
     res = np.clip(r, -1.0, 1.0)
     return res
@@ -64,7 +62,6 @@ def _pearson_r_p_value(a, b, axis):
 
     """
     r = _pearson_r(a, b, axis)
-    a = np.rollaxis(a, axis)
     df = a.shape[0] - 2
     t_squared = r**2 * (df / ((1.0 - r) * (1.0 + r)))
     _x = df/(df+t_squared)
@@ -99,9 +96,7 @@ def _rmse(a, b, axis):
     sklearn.metrics.mean_squared_error
 
     """
-    a = np.rollaxis(a, axis)
-    b = np.rollaxis(b, axis)
-    res = np.sqrt(((a - b) ** 2).mean(axis=0))
+    res = np.sqrt(((a - b) ** 2).mean(axis=axis))
     return res
 
 
@@ -128,9 +123,7 @@ def _mse(a, b, axis):
     sklearn.metrics.mean_squared_error
 
     """
-    a = np.rollaxis(a, axis)
-    b = np.rollaxis(b, axis)
-    res = ((a - b) ** 2).mean(axis=0)
+    res = ((a - b) ** 2).mean(axis=axis)
     return res
 
 
@@ -157,7 +150,5 @@ def _mae(a, b, axis):
     sklearn.metrics.mean_absolute_error
 
     """
-    a = np.rollaxis(a, axis)
-    b = np.rollaxis(b, axis)
-    res = (np.absolute(a - b)).mean(axis=0)
+    res = (np.absolute(a - b)).mean(axis=axis)
     return res

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -4,9 +4,10 @@ import pytest
 import xarray as xr
 from xarray.tests import assert_allclose
 
-from xskillscore.core.deterministic import _preprocess
-from xskillscore.core.np_deterministic import (_mae, _mse, _pearson_r,
-                                               _pearson_r_p_value, _rmse)
+from xskillscore.core.deterministic import (
+    _preprocess, mae, mse, pearson_r, pearson_r_p_value, rmse)
+from xskillscore.core.np_deterministic import (
+    _mae, _mse, _pearson_r, _pearson_r_p_value, _rmse)
 
 
 AXES = ('time', 'lat', 'lon', ('lat', 'lon'), ('time', 'lat', 'lon'))
@@ -56,171 +57,163 @@ def b_dask(b):
                         dims=['time', 'lat', 'lon']).chunk()
 
 
-# @pytest.mark.parametrize('dim', AXES)
-# def test_pearson_r_xr(a, b, dim):
-#     dim, axis = _preprocess(dim)
-#     actual = xr.apply_ufunc(_pearson_r, a, b,
-#                             input_core_dims=[dim, dim],
-#                             kwargs={'axis': axis},
-#                             dask='parallelized',
-#                             output_dtypes=[float])
-#     _a = a.values
-#     _b = b.values
-#     axis = tuple(a.dims.index(d) for d in dim)
-#     res = _pearson_r(_a, _b, axis)
-#     expected = actual.copy()
-#     expected.values = res
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize('dim', AXES)
+def test_pearson_r_xr(a, b, dim):
+    actual = pearson_r(a, b, dim)
+
+    dim, _ = _preprocess(dim)
+    if len(dim) > 1:
+        new_dim = '_'.join(dim)
+        _a = a.stack(**{new_dim: dim})
+        _b = b.stack(**{new_dim: dim})
+    else:
+        new_dim = dim[0]
+        _a = a
+        _b = b
+
+    axis = _a.dims.index(new_dim)
+    res = _pearson_r(_a.values, _b.values, axis)
+    expected = actual.copy()
+    expected.values = res
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize('dim', AXES)
-# def test_pearson_r_xr_dask(a_dask, b_dask, dim):
-#     dim, axis = _preprocess(dim)
-#     actual = xr.apply_ufunc(_pearson_r, a_dask, b_dask,
-#                             input_core_dims=[dim, dim],
-#                             kwargs={'axis': axis},
-#                             dask='parallelized',
-#                             output_dtypes=[float])
-#     _a_dask = a_dask.values
-#     _b_dask = b_dask.values
-#     axis = tuple(a_dask.dims.index(d) for d in dim)
-#     res = _pearson_r(_a_dask, _b_dask, axis)
-#     expected = actual.copy()
-#     expected.values = res
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize('dim', AXES)
+def test_pearson_r_xr_dask(a_dask, b_dask, dim):
+    actual = pearson_r(a_dask, b_dask, dim)
+
+    dim, _ = _preprocess(dim)
+    if len(dim) > 1:
+        new_dim = '_'.join(dim)
+        _a_dask = a_dask.stack(**{new_dim: dim})
+        _b_dask = b_dask.stack(**{new_dim: dim})
+    else:
+        new_dim = dim[0]
+        _a_dask = a_dask
+        _b_dask = b_dask
+
+    axis = _a_dask.dims.index(new_dim)
+    res = _pearson_r(_a_dask.values, _b_dask.values, axis)
+    expected = actual.copy()
+    expected.values = res
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize('dim', AXES)
-# def test_pearson_r_p_value_xr(a, b, dim):
-#     dim, axis = _preprocess(dim)
-#     actual = xr.apply_ufunc(_pearson_r_p_value, a, b,
-#                             input_core_dims=[dim, dim],
-#                             kwargs={'axis': axis},
-#                             dask='parallelized',
-#                             output_dtypes=[float])
-#     _a = a.values
-#     _b = b.values
-#     axis = tuple(a.dims.index(d) for d in dim)
-#     res = _pearson_r_p_value(_a, _b, axis)
-#     expected = actual.copy()
-#     expected.values = res
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize('dim', AXES)
+def test_pearson_r_p_value_xr(a, b, dim):
+    actual = pearson_r_p_value(a, b, dim)
+
+    dim, _ = _preprocess(dim)
+    if len(dim) > 1:
+        new_dim = '_'.join(dim)
+        _a = a.stack(**{new_dim: dim})
+        _b = b.stack(**{new_dim: dim})
+    else:
+        new_dim = dim[0]
+        _a = a
+        _b = b
+
+    axis = _a.dims.index(new_dim)
+    res = _pearson_r_p_value(_a.values, _b.values, axis)
+    expected = actual.copy()
+    expected.values = res
+    assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
 def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim):
-    dim, axis = _preprocess(dim)
-    actual = xr.apply_ufunc(_pearson_r_p_value, a_dask, b_dask,
-                            input_core_dims=[dim, dim],
-                            kwargs={'axis': axis},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a_dask = a_dask.values
-    _b_dask = b_dask.values
-    axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _pearson_r_p_value(_a_dask, _b_dask, axis)
+    actual = pearson_r_p_value(a_dask, b_dask, dim)
+
+    dim, _ = _preprocess(dim)
+    if len(dim) > 1:
+        new_dim = '_'.join(dim)
+        _a_dask = a_dask.stack(**{new_dim: dim})
+        _b_dask = b_dask.stack(**{new_dim: dim})
+    else:
+        new_dim = dim[0]
+        _a_dask = a_dask
+        _b_dask = b_dask
+
+    axis = _a_dask.dims.index(new_dim)
+    res = _pearson_r_p_value(_a_dask.values, _b_dask.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_rmse_r_xr(a, b, dim):
-    dim, axis = _preprocess(dim)
-    actual = xr.apply_ufunc(_rmse, a, b,
-                            input_core_dims=[dim, dim],
-                            kwargs={'axis': axis},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a = a.values
-    _b = b.values
-    axis = tuple(a.dims.index(d) for d in dim)
-    res = _rmse(_a, _b, axis)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize('dim', AXES)
+# def test_rmse_r_xr(a, b, dim):
+#     actual = rmse(a, b, dim)
+#     dim, axis = _preprocess(dim)
+#     _a = a.values
+#     _b = b.values
+#     axis = tuple(a.dims.index(d) for d in dim)
+#     res = _rmse(_a, _b, axis)
+#     expected = actual.copy()
+#     expected.values = res
+#     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_rmse_r_xr_dask(a_dask, b_dask, dim):
-    dim, axis = _preprocess(dim)
-    actual = xr.apply_ufunc(_rmse, a_dask, b_dask,
-                            input_core_dims=[dim, dim],
-                            kwargs={'axis': axis},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a_dask = a_dask.values
-    _b_dask = b_dask.values
-    axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _rmse(_a_dask, _b_dask, axis)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize('dim', AXES)
+# def test_rmse_r_xr_dask(a_dask, b_dask, dim):
+#     actual = rmse(a_dask, b_dask, dim)
+#     dim, axis = _preprocess(dim)
+#     _a_dask = a_dask.values
+#     _b_dask = b_dask.values
+#     axis = tuple(a_dask.dims.index(d) for d in dim)
+#     res = _rmse(_a_dask, _b_dask, axis)
+#     expected = actual.copy()
+#     expected.values = res
+#     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_mse_r_xr(a, b, dim):
-    dim, axis = _preprocess(dim)
-    actual = xr.apply_ufunc(_mse, a, b,
-                            input_core_dims=[dim, dim],
-                            kwargs={'axis': axis},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a = a.values
-    _b = b.values
-    axis = tuple(a.dims.index(d) for d in dim)
-    res = _mse(_a, _b, axis)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize('dim', AXES)
+# def test_mse_r_xr(a, b, dim):
+#     actual = mse(a, b, dim)
+#     dim, axis = _preprocess(dim)
+#     _a = a.values
+#     _b = b.values
+#     axis = tuple(a.dims.index(d) for d in dim)
+#     res = _mse(_a, _b, axis)
+#     expected = actual.copy()
+#     expected.values = res
+#     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_mse_r_xr_dask(a_dask, b_dask, dim):
-    dim, axis = _preprocess(dim)
-    actual = xr.apply_ufunc(_mse, a_dask, b_dask,
-                            input_core_dims=[dim, dim],
-                            kwargs={'axis': axis},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a_dask = a_dask.values
-    _b_dask = b_dask.values
-    axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _mse(_a_dask, _b_dask, axis)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize('dim', AXES)
+# def test_mse_r_xr_dask(a_dask, b_dask, dim):
+#     actual = mse(a_dask, b_dask, dim)
+#     dim, axis = _preprocess(dim)
+#     _a_dask = a_dask.values
+#     _b_dask = b_dask.values
+#     axis = tuple(a_dask.dims.index(d) for d in dim)
+#     res = _mse(_a_dask, _b_dask, axis)
+#     expected = actual.copy()
+#     expected.values = res
+#     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_mae_r_xr(a, b, dim):
-    dim, axis = _preprocess(dim)
-    actual = xr.apply_ufunc(_mae, a, b,
-                            input_core_dims=[dim, dim],
-                            kwargs={'axis': axis},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a = a.values
-    _b = b.values
-    axis = tuple(a.dims.index(d) for d in dim)
-    res = _mae(_a, _b, axis)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize('dim', AXES)
+# def test_mae_r_xr(a, b, dim):
+#     actual = mae(a, b, dim)
+#     dim, axis = _preprocess(dim)
+#     _a = a.values
+#     _b = b.values
+#     axis = tuple(a.dims.index(d) for d in dim)
+#     res = _mae(_a, _b, axis)
+#     expected = actual.copy()
+#     expected.values = res
+#     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_mae_r_xr_dask(a_dask, b_dask, dim):
-    dim, axis = _preprocess(dim)
-    actual = xr.apply_ufunc(_mae, a_dask, b_dask,
-                            input_core_dims=[dim, dim],
-                            kwargs={'axis': axis},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a_dask = a_dask.values
-    _b_dask = b_dask.values
-    axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _mae(_a_dask, _b_dask, axis)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize('dim', AXES)
+# def test_mae_r_xr_dask(a_dask, b_dask, dim):
+#     actual = mae(a_dask, b_dask, dim)
+#     dim, axis = _preprocess(dim)
+#     _a_dask = a_dask.values
+#     _b_dask = b_dask.values
+#     axis = tuple(a_dask.dims.index(d) for d in dim)
+#     res = _mae(_a_dask, _b_dask, axis)
+#     expected = actual.copy()
+#     expected.values = res
+#     assert_allclose(actual, expected)

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -141,79 +141,79 @@ def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim):
     assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize('dim', AXES)
-# def test_rmse_r_xr(a, b, dim):
-#     actual = rmse(a, b, dim)
-#     dim, axis = _preprocess(dim)
-#     _a = a.values
-#     _b = b.values
-#     axis = tuple(a.dims.index(d) for d in dim)
-#     res = _rmse(_a, _b, axis)
-#     expected = actual.copy()
-#     expected.values = res
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize('dim', AXES)
+def test_rmse_r_xr(a, b, dim):
+    actual = rmse(a, b, dim)
+    dim, axis = _preprocess(dim)
+    _a = a.values
+    _b = b.values
+    axis = tuple(a.dims.index(d) for d in dim)
+    res = _rmse(_a, _b, axis)
+    expected = actual.copy()
+    expected.values = res
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize('dim', AXES)
-# def test_rmse_r_xr_dask(a_dask, b_dask, dim):
-#     actual = rmse(a_dask, b_dask, dim)
-#     dim, axis = _preprocess(dim)
-#     _a_dask = a_dask.values
-#     _b_dask = b_dask.values
-#     axis = tuple(a_dask.dims.index(d) for d in dim)
-#     res = _rmse(_a_dask, _b_dask, axis)
-#     expected = actual.copy()
-#     expected.values = res
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize('dim', AXES)
+def test_rmse_r_xr_dask(a_dask, b_dask, dim):
+    actual = rmse(a_dask, b_dask, dim)
+    dim, axis = _preprocess(dim)
+    _a_dask = a_dask.values
+    _b_dask = b_dask.values
+    axis = tuple(a_dask.dims.index(d) for d in dim)
+    res = _rmse(_a_dask, _b_dask, axis)
+    expected = actual.copy()
+    expected.values = res
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize('dim', AXES)
-# def test_mse_r_xr(a, b, dim):
-#     actual = mse(a, b, dim)
-#     dim, axis = _preprocess(dim)
-#     _a = a.values
-#     _b = b.values
-#     axis = tuple(a.dims.index(d) for d in dim)
-#     res = _mse(_a, _b, axis)
-#     expected = actual.copy()
-#     expected.values = res
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize('dim', AXES)
+def test_mse_r_xr(a, b, dim):
+    actual = mse(a, b, dim)
+    dim, axis = _preprocess(dim)
+    _a = a.values
+    _b = b.values
+    axis = tuple(a.dims.index(d) for d in dim)
+    res = _mse(_a, _b, axis)
+    expected = actual.copy()
+    expected.values = res
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize('dim', AXES)
-# def test_mse_r_xr_dask(a_dask, b_dask, dim):
-#     actual = mse(a_dask, b_dask, dim)
-#     dim, axis = _preprocess(dim)
-#     _a_dask = a_dask.values
-#     _b_dask = b_dask.values
-#     axis = tuple(a_dask.dims.index(d) for d in dim)
-#     res = _mse(_a_dask, _b_dask, axis)
-#     expected = actual.copy()
-#     expected.values = res
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize('dim', AXES)
+def test_mse_r_xr_dask(a_dask, b_dask, dim):
+    actual = mse(a_dask, b_dask, dim)
+    dim, axis = _preprocess(dim)
+    _a_dask = a_dask.values
+    _b_dask = b_dask.values
+    axis = tuple(a_dask.dims.index(d) for d in dim)
+    res = _mse(_a_dask, _b_dask, axis)
+    expected = actual.copy()
+    expected.values = res
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize('dim', AXES)
-# def test_mae_r_xr(a, b, dim):
-#     actual = mae(a, b, dim)
-#     dim, axis = _preprocess(dim)
-#     _a = a.values
-#     _b = b.values
-#     axis = tuple(a.dims.index(d) for d in dim)
-#     res = _mae(_a, _b, axis)
-#     expected = actual.copy()
-#     expected.values = res
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize('dim', AXES)
+def test_mae_r_xr(a, b, dim):
+    actual = mae(a, b, dim)
+    dim, axis = _preprocess(dim)
+    _a = a.values
+    _b = b.values
+    axis = tuple(a.dims.index(d) for d in dim)
+    res = _mae(_a, _b, axis)
+    expected = actual.copy()
+    expected.values = res
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize('dim', AXES)
-# def test_mae_r_xr_dask(a_dask, b_dask, dim):
-#     actual = mae(a_dask, b_dask, dim)
-#     dim, axis = _preprocess(dim)
-#     _a_dask = a_dask.values
-#     _b_dask = b_dask.values
-#     axis = tuple(a_dask.dims.index(d) for d in dim)
-#     res = _mae(_a_dask, _b_dask, axis)
-#     expected = actual.copy()
-#     expected.values = res
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize('dim', AXES)
+def test_mae_r_xr_dask(a_dask, b_dask, dim):
+    actual = mae(a_dask, b_dask, dim)
+    dim, axis = _preprocess(dim)
+    _a_dask = a_dask.values
+    _b_dask = b_dask.values
+    axis = tuple(a_dask.dims.index(d) for d in dim)
+    res = _mae(_a_dask, _b_dask, axis)
+    expected = actual.copy()
+    expected.values = res
+    assert_allclose(actual, expected)

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -4,8 +4,12 @@ import pytest
 import xarray as xr
 from xarray.tests import assert_allclose
 
+from xskillscore.core.deterministic import _preprocess
 from xskillscore.core.np_deterministic import (_mae, _mse, _pearson_r,
                                                _pearson_r_p_value, _rmse)
+
+
+AXES = ('time', 'lat', 'lon', ('lat', 'lon'), ('time', 'lat', 'lon'))
 
 
 @pytest.fixture
@@ -52,160 +56,170 @@ def b_dask(b):
                         dims=['time', 'lat', 'lon']).chunk()
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
-def test_pearson_r_xr(a, b, dim):
-    actual = xr.apply_ufunc(_pearson_r, a, b,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a = a.values
-    _b = b.values
-    axis = a.dims.index(dim)
-    res = _pearson_r(_a, _b, axis)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize('dim', AXES)
+# def test_pearson_r_xr(a, b, dim):
+#     dim, axis = _preprocess(dim)
+#     actual = xr.apply_ufunc(_pearson_r, a, b,
+#                             input_core_dims=[dim, dim],
+#                             kwargs={'axis': axis},
+#                             dask='parallelized',
+#                             output_dtypes=[float])
+#     _a = a.values
+#     _b = b.values
+#     axis = tuple(a.dims.index(d) for d in dim)
+#     res = _pearson_r(_a, _b, axis)
+#     expected = actual.copy()
+#     expected.values = res
+#     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
-def test_pearson_r_xr_dask(a_dask, b_dask, dim):
-    actual = xr.apply_ufunc(_pearson_r, a_dask, b_dask,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a_dask = a_dask.values
-    _b_dask = b_dask.values
-    axis = a_dask.dims.index(dim)
-    res = _pearson_r(_a_dask, _b_dask, axis)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize('dim', AXES)
+# def test_pearson_r_xr_dask(a_dask, b_dask, dim):
+#     dim, axis = _preprocess(dim)
+#     actual = xr.apply_ufunc(_pearson_r, a_dask, b_dask,
+#                             input_core_dims=[dim, dim],
+#                             kwargs={'axis': axis},
+#                             dask='parallelized',
+#                             output_dtypes=[float])
+#     _a_dask = a_dask.values
+#     _b_dask = b_dask.values
+#     axis = tuple(a_dask.dims.index(d) for d in dim)
+#     res = _pearson_r(_a_dask, _b_dask, axis)
+#     expected = actual.copy()
+#     expected.values = res
+#     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
-def test_pearson_r_p_value_xr(a, b, dim):
-    actual = xr.apply_ufunc(_pearson_r_p_value, a, b,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
-                            dask='parallelized',
-                            output_dtypes=[float])
-    _a = a.values
-    _b = b.values
-    axis = a.dims.index(dim)
-    res = _pearson_r_p_value(_a, _b, axis)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize('dim', AXES)
+# def test_pearson_r_p_value_xr(a, b, dim):
+#     dim, axis = _preprocess(dim)
+#     actual = xr.apply_ufunc(_pearson_r_p_value, a, b,
+#                             input_core_dims=[dim, dim],
+#                             kwargs={'axis': axis},
+#                             dask='parallelized',
+#                             output_dtypes=[float])
+#     _a = a.values
+#     _b = b.values
+#     axis = tuple(a.dims.index(d) for d in dim)
+#     res = _pearson_r_p_value(_a, _b, axis)
+#     expected = actual.copy()
+#     expected.values = res
+#     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
+@pytest.mark.parametrize('dim', AXES)
 def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim):
+    dim, axis = _preprocess(dim)
     actual = xr.apply_ufunc(_pearson_r_p_value, a_dask, b_dask,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
+                            input_core_dims=[dim, dim],
+                            kwargs={'axis': axis},
                             dask='parallelized',
                             output_dtypes=[float])
     _a_dask = a_dask.values
     _b_dask = b_dask.values
-    axis = a_dask.dims.index(dim)
+    axis = tuple(a_dask.dims.index(d) for d in dim)
     res = _pearson_r_p_value(_a_dask, _b_dask, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
+@pytest.mark.parametrize('dim', AXES)
 def test_rmse_r_xr(a, b, dim):
+    dim, axis = _preprocess(dim)
     actual = xr.apply_ufunc(_rmse, a, b,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
+                            input_core_dims=[dim, dim],
+                            kwargs={'axis': axis},
                             dask='parallelized',
                             output_dtypes=[float])
     _a = a.values
     _b = b.values
-    axis = a.dims.index(dim)
+    axis = tuple(a.dims.index(d) for d in dim)
     res = _rmse(_a, _b, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
+@pytest.mark.parametrize('dim', AXES)
 def test_rmse_r_xr_dask(a_dask, b_dask, dim):
+    dim, axis = _preprocess(dim)
     actual = xr.apply_ufunc(_rmse, a_dask, b_dask,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
+                            input_core_dims=[dim, dim],
+                            kwargs={'axis': axis},
                             dask='parallelized',
                             output_dtypes=[float])
     _a_dask = a_dask.values
     _b_dask = b_dask.values
-    axis = a_dask.dims.index(dim)
+    axis = tuple(a_dask.dims.index(d) for d in dim)
     res = _rmse(_a_dask, _b_dask, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
+@pytest.mark.parametrize('dim', AXES)
 def test_mse_r_xr(a, b, dim):
+    dim, axis = _preprocess(dim)
     actual = xr.apply_ufunc(_mse, a, b,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
+                            input_core_dims=[dim, dim],
+                            kwargs={'axis': axis},
                             dask='parallelized',
                             output_dtypes=[float])
     _a = a.values
     _b = b.values
-    axis = a.dims.index(dim)
+    axis = tuple(a.dims.index(d) for d in dim)
     res = _mse(_a, _b, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
+@pytest.mark.parametrize('dim', AXES)
 def test_mse_r_xr_dask(a_dask, b_dask, dim):
+    dim, axis = _preprocess(dim)
     actual = xr.apply_ufunc(_mse, a_dask, b_dask,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
+                            input_core_dims=[dim, dim],
+                            kwargs={'axis': axis},
                             dask='parallelized',
                             output_dtypes=[float])
     _a_dask = a_dask.values
     _b_dask = b_dask.values
-    axis = a_dask.dims.index(dim)
+    axis = tuple(a_dask.dims.index(d) for d in dim)
     res = _mse(_a_dask, _b_dask, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
+@pytest.mark.parametrize('dim', AXES)
 def test_mae_r_xr(a, b, dim):
+    dim, axis = _preprocess(dim)
     actual = xr.apply_ufunc(_mae, a, b,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
+                            input_core_dims=[dim, dim],
+                            kwargs={'axis': axis},
                             dask='parallelized',
                             output_dtypes=[float])
     _a = a.values
     _b = b.values
-    axis = a.dims.index(dim)
+    axis = tuple(a.dims.index(d) for d in dim)
     res = _mae(_a, _b, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', ('time', 'lat', 'lon'))
+@pytest.mark.parametrize('dim', AXES)
 def test_mae_r_xr_dask(a_dask, b_dask, dim):
+    dim, axis = _preprocess(dim)
     actual = xr.apply_ufunc(_mae, a_dask, b_dask,
-                            input_core_dims=[[dim], [dim]],
-                            kwargs={'axis': -1},
+                            input_core_dims=[dim, dim],
+                            kwargs={'axis': axis},
                             dask='parallelized',
                             output_dtypes=[float])
     _a_dask = a_dask.values
     _b_dask = b_dask.values
-    axis = a_dask.dims.index(dim)
+    axis = tuple(a_dask.dims.index(d) for d in dim)
     res = _mae(_a_dask, _b_dask, axis)
     expected = actual.copy()
     expected.values = res


### PR DESCRIPTION
I think it's ready

https://github.com/raybellwaves/xskillscore/issues/8

I think when you call xr.apply_ufunc, it automatically rolls the axes so I just had to pass in the right negative numbers to `axis` kwargs https://xarray.pydata.org/en/stable/generated/xarray.apply_ufunc.html
```
Core dimensions are automatically moved to the last axes of input variables before applying func, which facilitates using NumPy style generalized ufuncs [2].
```

A quick sanity check
```
import numpy as np
import xarray as xr
from xskillscore import mae

ds = xr.tutorial.open_dataset('air_temperature').isel(time=[0, 1, 2],
                                                      lat=[3, 4, 5],
                                                      lon=[6, 7, 8])
ds['ref'] = xr.concat((
    ds['air'].isel(time=i) + i
    for i in range(len(ds['time']))
), 'time')

print('test diagn\n\n')
mae(ds['air'], ds['ref'], ['time'])
for i in range(3):
    np.mean(np.absolute((ds['air'].isel(lat=i, lon=i).astype(float) -
                         ds['ref'].isel(lat=i, lon=i).astype(float))))

print('test time\n\n')
mae(ds['air'], ds['ref'], ['lat', 'lon'])
for time in ds['time']:
    np.mean(np.absolute((ds['air'].sel(time=time).astype(float) -
                         ds['ref'].sel(time=time).astype(float))))
```

output
```
test diagn
<xarray.DataArray (lat: 3, lon: 3)>
array([[1., 1., 1.],
       [1., 1., 1.],
       [1., 1., 1.]], dtype=float32)
Coordinates:
  * lat      (lat) float32 67.5 65.0 62.5
  * lon      (lon) float32 215.0 217.5 220.0
<xarray.DataArray ()>
array(1.)
Coordinates:
    lat      float32 67.5
    lon      float32 215.0
<xarray.DataArray ()>
array(1.)
Coordinates:
    lat      float32 65.0
    lon      float32 217.5
<xarray.DataArray ()>
array(1.)
Coordinates:
    lat      float32 62.5
    lon      float32 220.0


test time
<xarray.DataArray (time: 3)>
array([0., 1., 2.], dtype=float32)
Coordinates:
  * time     (time) datetime64[ns] 2013-01-01 ... 2013-01-01T12:00:00
<xarray.DataArray ()>
array(0.)
Coordinates:
    time     datetime64[ns] 2013-01-01
<xarray.DataArray ()>
array(1.)
Coordinates:
    time     datetime64[ns] 2013-01-01T06:00:00
<xarray.DataArray ()>
array(2.)
Coordinates:
    time     datetime64[ns] 2013-01-01T12:00:00

```

- [x] make correlations accurate
- [x] update test_np_deterministic
- [x] do more sanity checks
- [x] update np_deterministic docs
