### PR TITLE
Add accessors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,3 +64,16 @@ Examples
    crps_gaussian = xs.crps_gaussian(obs, fct.mean('time'), fct.std('time'))
 
    threshold_brier_score = xs.threshold_brier_score(obs, fct, 0.7)
+
+   # You can also use xskillscore as a method of your dataset.
+   ds = xr.Dataset()
+   ds['obs_var'] = obs
+   ds['fct_var'] = fct
+
+   # This is the equivalent of r = xs.pearson_r(obs, fct, 'time')
+   r = ds.xs.rmse('obs_var', 'fct_var', 'time')
+
+   # If fct is not a part of the dataset, inputting a separate
+   # DataArray as an argument works as well
+   ds = ds.drop('fct_var')
+   r = ds.xs.rmse('obs_var', fct, 'time')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 DISTNAME = 'xskillscore'
-VERSION = '0.0.2'
+VERSION = '0.0.3'
 LICENSE = 'Apache'
 AUTHOR = 'Ray Bell'
 AUTHOR_EMAIL = 'rayjohnbell0@gmail.com'

--- a/xskillscore/__init__.py
+++ b/xskillscore/__init__.py
@@ -4,3 +4,4 @@ from .core.probabilistic import xr_crps_ensemble as crps_ensemble
 from .core.probabilistic import xr_crps_gaussian as crps_gaussian
 from .core.probabilistic import \
     xr_threshold_brier_score as threshold_brier_score
+from .core.accessor import XSkillScoreAccessor

--- a/xskillscore/core/accessor.py
+++ b/xskillscore/core/accessor.py
@@ -1,0 +1,65 @@
+import xarray as xr
+
+from.deterministic import pearson_r, pearson_r_p_value, rmse, mse, mae
+from.probabilistic import (xr_crps_gaussian, xr_crps_ensemble,
+                           xr_threshold_brier_score)
+
+
+@xr.register_dataset_accessor('xs')
+class XSkillScoreAccessor(object):
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+
+    def _in_ds(self, x):
+        """
+        If x is not a string, presumably an array, return the array.
+        Else x is a string, presumably within ds, return the ds variable.
+        """
+        if not isinstance(x, str):
+            return x
+        else:
+            return self._obj[x]
+
+    def pearson_r(self, a, b, dim):
+        a = self._in_ds(a)
+        b = self._in_ds(b)
+        return pearson_r(a, b, dim)
+
+    def pearson_r_p_value(self, a, b, dim):
+        a = self._in_ds(a)
+        b = self._in_ds(b)
+        return pearson_r_p_value(a, b, dim)
+
+    def rmse(self, a, b, dim):
+        a = self._in_ds(a)
+        b = self._in_ds(b)
+        return rmse(a, b, dim)
+
+    def mse(self, a, b, dim):
+        a = self._in_ds(a)
+        b = self._in_ds(b)
+        return mse(a, b, dim)
+
+    def mae(self, a, b, dim):
+        a = self._in_ds(a)
+        b = self._in_ds(b)
+        return mae(a, b, dim)
+
+    def crps_gaussian(self, observations, mu, sig):
+        observations = self._in_ds(observations)
+        mu = self._in_ds(mu)
+        sig = self._in_ds(sig)
+        return xr_crps_gaussian(observations, mu, sig)
+
+    def crps_ensemble(self, observations, forecasts):
+        observations = self._in_ds(observations)
+        forecasts = self._in_ds(forecasts)
+        return xr_crps_ensemble(observations, forecasts)
+
+    def threshold_brier_score(self, observations, forecasts, threshold,
+                              issorted=False, axis=-1):
+        observations = self._in_ds(observations)
+        forecasts = self._in_ds(forecasts)
+        threshold = self._in_ds(threshold)
+        return xr_threshold_brier_score(observations, forecasts, threshold,
+                                        issorted=issorted, axis=axis)

--- a/xskillscore/tests/test_accessor.py
+++ b/xskillscore/tests/test_accessor.py
@@ -1,0 +1,87 @@
+import pytest
+import numpy as np
+import pandas as pd
+import xarray as xr
+from xarray.tests import assert_allclose
+
+from xskillscore.core.deterministic import (
+    pearson_r, pearson_r_p_value, rmse, mse, mae)
+from xskillscore.core.probabilistic import (
+    xr_crps_ensemble, xr_crps_gaussian, xr_threshold_brier_score)
+from xskillscore.core.accessor import XSkillScoreAccessor
+
+
+@pytest.fixture
+def ds_dask():
+    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+    lats = np.arange(4)
+    lons = np.arange(5)
+    a = xr.DataArray(
+        np.random.rand(len(dates), len(lats), len(lons)),
+        coords=[dates, lats, lons],
+        dims=['time', 'lat', 'lon']
+    ).chunk()
+    b = xr.DataArray(
+        np.random.rand(len(dates), len(lats), len(lons)),
+        coords=[dates, lats, lons],
+        dims=['time', 'lat', 'lon']
+    ).chunk()
+
+    ds = xr.Dataset()
+    ds['a'] = a
+    ds['b'] = b
+    return ds
+
+
+@pytest.fixture
+def mu():
+    return xr.DataArray(5)
+
+
+@pytest.fixture
+def sigma():
+    return xr.DataArray(6)
+
+
+def test_pearson_r_accessor(ds_dask):
+    ds = ds_dask.load()
+
+    dim = 'time'
+    actual = pearson_r(ds['a'], ds['b'], dim)
+    expected = ds.xs.pearson_r('a', 'b', dim)
+    assert_allclose(actual, expected)
+
+
+def test_rmse_accessor_dask(ds_dask):
+    dim = 'lon'
+    actual = rmse(ds_dask['a'], ds_dask['b'], dim).compute()
+    expected = ds_dask.xs.rmse('a', 'b', dim).compute()
+    assert_allclose(actual, expected)
+
+
+def test_mae_accessor_outer_array(ds_dask):
+    ds = ds_dask.load()
+    b = ds['b']
+    ds = ds.drop('b')
+    dim = 'lat'
+
+    actual = mae(ds['a'], b, dim)
+    expected = ds.xs.mae('a', b, dim)
+    assert_allclose(actual, expected)
+
+
+def test_crps_gaussian_accessor(ds_dask, mu, sigma):
+    ds = ds_dask.load()
+    ds['mu'] = mu
+    ds['sigma'] = sigma
+
+    actual = xr_crps_gaussian(ds['a'], mu, sigma)
+    expected = ds.xs.crps_gaussian('a', 'mu', 'sigma')
+    assert_allclose(actual, expected)
+
+
+def test_crps_gaussian_accessor_outer_array(ds_dask, mu, sigma):
+    ds = ds_dask.load()
+    actual = xr_crps_gaussian(ds['a'], mu, sigma)
+    expected = ds.xs.crps_gaussian('a', mu, sigma)
+    assert_allclose(actual, expected)


### PR DESCRIPTION
Give the users the option of doing: `ds.xs.rmse('air', 'airx2', 'time')` rather than `xs.rmse(ds['air'], ds['airx2'], 'time')`, although they can also do, `ds.xs.rmse('air', ds2['airx2'], 'time')` if `airx2` is not a variable in the original ds.

```
ds = xr.tutorial.open_dataset('air_temperature')
ds['airx2'] = ds['air']
xs.rmse(ds['air'], ds['airx2'], 'time')
ds.xs.rmse('air', 'airx2', 'time')
```
