### PR TITLE
Add properscoring.brier_score and test lazy compute via dask

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ xskillscore: Metrics for verifying forecasts
 .. image:: https://img.shields.io/pypi/v/xskillscore.svg
    :target: https://pypi.python.org/pypi/xskillscore/
 .. image:: https://anaconda.org/conda-forge/xskillscore/badges/version.svg
-   :target: https://anaconda.org/conda-forge/xskillscore/ 
+   :target: https://anaconda.org/conda-forge/xskillscore/
 
 **xskillscore** is an open source project and Python package that provides verification metrics of deterministic (and probabilistic from `properscoring`) forecasts with `xarray`.
 
@@ -61,8 +61,8 @@ Examples
 
    mse = xs.mse(obs, fct, 'time')
 
-   mae = xs.mae(obs, fct, 'time') 
-   
+   mae = xs.mae(obs, fct, 'time')
+
    # You can also specify multiple axes for deterministic metrics
    r = xs.pearson_r(obs, fct, ['lat', 'lon'])
 
@@ -72,6 +72,8 @@ Examples
    crps_gaussian = xs.crps_gaussian(obs, fct.mean('time'), fct.std('time'))
 
    threshold_brier_score = xs.threshold_brier_score(obs, fct, 0.7)
+
+   brier_score = xs.brier_score(obs > .5, fct)
 
    # You can also use xskillscore as a method of your dataset.
    ds = xr.Dataset()
@@ -90,4 +92,4 @@ What projects leverage xskillscore?
 -----------------------------------
 
 - `climpred <https://climpred.readthedocs.io>`_: An xarray wrapper for analysis of ensemble forecast models for climate prediction.
-- `esmlab <https://esmlab.readthedocs.io>`_: Tools for working with earth system multi-model analyses with xarray. 
+- `esmlab <https://esmlab.readthedocs.io>`_: Tools for working with earth system multi-model analyses with xarray.

--- a/xskillscore/__init__.py
+++ b/xskillscore/__init__.py
@@ -4,4 +4,6 @@ from .core.probabilistic import xr_crps_ensemble as crps_ensemble
 from .core.probabilistic import xr_crps_gaussian as crps_gaussian
 from .core.probabilistic import \
     xr_threshold_brier_score as threshold_brier_score
+from .core.probabilistic import \
+    xr_brier_score as brier_score
 from .core.accessor import XSkillScoreAccessor

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -1,5 +1,5 @@
 import xarray as xr
-from properscoring import crps_ensemble, crps_gaussian, threshold_brier_score
+from properscoring import crps_ensemble, crps_gaussian, threshold_brier_score, brier_score
 
 
 def xr_crps_gaussian(observations, mu, sig):
@@ -39,7 +39,7 @@ def xr_crps_gaussian(observations, mu, sig):
                           mu,
                           sig,
                           input_core_dims=[[], [], []],
-                          dask='parallelized',
+                          dask='allowed',
                           output_dtypes=[float])
 
 
@@ -70,7 +70,52 @@ def xr_crps_ensemble(observations, forecasts):
                           observations,
                           forecasts,
                           input_core_dims=[[], []],
-                          dask='parallelized',
+                          dask='allowed',
+                          output_dtypes=[float])
+
+
+def xr_brier_score(observations,
+                   forecasts
+                   ):
+    """
+    xarray version of properscoring.brier_score: Calculate Brier score (BS).
+
+    ..math:
+        BS(p, k) = (p_1 - k)^2,
+
+    Parameters
+    ----------
+    observations : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
+     scalars, Mix of labeled and/or unlabeled observations arrays.
+    forecasts : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
+     scalars, Mix of labeled and/or unlabeled forecasts arrays.
+
+
+    Returns
+    -------
+    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
+    numpy.ndarray, the first type on that list to appear on an input.
+
+    References
+    ----------
+    Gneiting, Tilmann, and Adrian E Raftery. “Strictly Proper Scoring Rules,
+      Prediction, and Estimation.” Journal of the American Statistical
+      Association 102, no. 477 (March 1, 2007): 359–78.
+      https://doi.org/10/c6758w.
+
+
+    See Also
+    --------
+    properscoring.brier_score
+    xarray.apply_ufunc
+    """
+    if forecasts.dims != observations.dims:
+        observations, forecasts = xr.broadcast(observations, forecasts)
+    return xr.apply_ufunc(brier_score,
+                          observations,
+                          forecasts,
+                          input_core_dims=[[], []],
+                          dask='allowed',
                           output_dtypes=[float])
 
 
@@ -129,5 +174,5 @@ def xr_threshold_brier_score(observations,
                               'axis': axis,
                               'issorted': issorted
                           },
-                          dask='parallelized',
+                          dask='allowed',
                           output_dtypes=[float])

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -60,6 +60,7 @@ def b_dask(b):
 @pytest.mark.parametrize('dim', AXES)
 def test_pearson_r_xr(a, b, dim):
     actual = pearson_r(a, b, dim)
+    assert actual.chunks is None
 
     dim, _ = _preprocess(dim)
     if len(dim) > 1:
@@ -81,6 +82,7 @@ def test_pearson_r_xr(a, b, dim):
 @pytest.mark.parametrize('dim', AXES)
 def test_pearson_r_xr_dask(a_dask, b_dask, dim):
     actual = pearson_r(a_dask, b_dask, dim)
+    assert actual.chunks is not None
 
     dim, _ = _preprocess(dim)
     if len(dim) > 1:
@@ -102,6 +104,7 @@ def test_pearson_r_xr_dask(a_dask, b_dask, dim):
 @pytest.mark.parametrize('dim', AXES)
 def test_pearson_r_p_value_xr(a, b, dim):
     actual = pearson_r_p_value(a, b, dim)
+    assert actual.chunks is None
 
     dim, _ = _preprocess(dim)
     if len(dim) > 1:
@@ -123,6 +126,7 @@ def test_pearson_r_p_value_xr(a, b, dim):
 @pytest.mark.parametrize('dim', AXES)
 def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim):
     actual = pearson_r_p_value(a_dask, b_dask, dim)
+    assert actual.chunks is not None
 
     dim, _ = _preprocess(dim)
     if len(dim) > 1:
@@ -144,6 +148,8 @@ def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim):
 @pytest.mark.parametrize('dim', AXES)
 def test_rmse_r_xr(a, b, dim):
     actual = rmse(a, b, dim)
+    assert actual.chunks is None
+
     dim, axis = _preprocess(dim)
     _a = a.values
     _b = b.values
@@ -157,6 +163,8 @@ def test_rmse_r_xr(a, b, dim):
 @pytest.mark.parametrize('dim', AXES)
 def test_rmse_r_xr_dask(a_dask, b_dask, dim):
     actual = rmse(a_dask, b_dask, dim)
+    assert actual.chunks is not None
+
     dim, axis = _preprocess(dim)
     _a_dask = a_dask.values
     _b_dask = b_dask.values
@@ -170,6 +178,8 @@ def test_rmse_r_xr_dask(a_dask, b_dask, dim):
 @pytest.mark.parametrize('dim', AXES)
 def test_mse_r_xr(a, b, dim):
     actual = mse(a, b, dim)
+    assert actual.chunks is None
+
     dim, axis = _preprocess(dim)
     _a = a.values
     _b = b.values
@@ -183,6 +193,8 @@ def test_mse_r_xr(a, b, dim):
 @pytest.mark.parametrize('dim', AXES)
 def test_mse_r_xr_dask(a_dask, b_dask, dim):
     actual = mse(a_dask, b_dask, dim)
+    assert actual.chunks is not None
+
     dim, axis = _preprocess(dim)
     _a_dask = a_dask.values
     _b_dask = b_dask.values
@@ -196,6 +208,8 @@ def test_mse_r_xr_dask(a_dask, b_dask, dim):
 @pytest.mark.parametrize('dim', AXES)
 def test_mae_r_xr(a, b, dim):
     actual = mae(a, b, dim)
+    assert actual.chunks is None
+
     dim, axis = _preprocess(dim)
     _a = a.values
     _b = b.values
@@ -209,6 +223,8 @@ def test_mae_r_xr(a, b, dim):
 @pytest.mark.parametrize('dim', AXES)
 def test_mae_r_xr_dask(a_dask, b_dask, dim):
     actual = mae(a_dask, b_dask, dim)
+    assert actual.chunks is not None
+
     dim, axis = _preprocess(dim)
     _a_dask = a_dask.values
     _b_dask = b_dask.values

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -6,7 +6,7 @@ import xarray as xr
 from properscoring import crps_ensemble, crps_gaussian, threshold_brier_score
 from xarray.tests import assert_identical
 from xskillscore.core.probabilistic import (xr_crps_ensemble, xr_crps_gaussian,
-                                            xr_threshold_brier_score)
+                                            xr_threshold_brier_score, xr_brier_score)
 
 
 @pytest.fixture
@@ -64,9 +64,9 @@ def test_xr_threshold_brier_score_dask(a_dask, b_dask):
     expected = xr.DataArray(expected, coords=a_dask.coords)
     # test for numerical identity of xr_threshold and threshold
     assert_identical(actual, expected)
-    # test that xr_crps_ensemble returns chunks
+    # test that xr_threshold_brier_score returns chunks
     assert actual.chunks is not None
-    # show that crps_ensemble returns no chunks
+    # show that xr_threshold_brier_score returns no chunks
     assert expected.chunks is None
 
 
@@ -86,4 +86,9 @@ def test_xr_threshold_brier_score_dask_b_float(a_dask, b_dask):
 def test_xr_threshold_brier_score_dask_b_int(a_dask, b_dask):
     threshold = 0
     actual = xr_threshold_brier_score(a_dask, b_dask, threshold)
+    assert actual is not None
+
+
+def test_xr_brier_score_dask(a_dask, b_dask):
+    actual = xr_brier_score((a_dask > .5), b_dask)
     assert actual is not None


### PR DESCRIPTION
- `properscoring.brier_score` implemented
- new tests to check whether results of chunked inputs are lazy (these fail!) see https://github.com/raybellwaves/xskillscore/issues/17

