### PR TITLE
Add optional weighting to `xskillscore` functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Examples
    r = xs.pearson_r(obs, fct, ["lat", "lon"])
    
    # You can weight over the dimensions the function is being applied
-   # to by passing the argument ``weights=weight`` with a DataArray
+   # to by passing the argument ``weights=weight`` with a xr.DataArray
    # containing the dimension(s) being reduced.
    cos = np.abs(np.cos(np.arange(4)))
    wgts = np.tile(cos, (5, 1)).reshape(4, 5)

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,21 @@ Examples
 
    # You can also specify multiple axes for deterministic metrics:
    r = xs.pearson_r(obs, fct, ["lat", "lon"])
-
+   
+   # You can weight over the dimensions the function is being applied
+   # to by passing the argument ``weights=weight`` with a DataArray
+   # containing the dimension(s) being reduced.
+   cos = np.abs(np.cos(np.arange(4)))
+   wgts = np.tile(cos, (5, 1)).reshape(4, 5)
+   wgt = xr.DataArray(
+      wgts,
+      coords=[
+         np.arange(4),
+         np.arange(5),
+      ],
+      dims=["lat", "lon"],
+   )
+   rmse_wgt = xs.rmse(obs, fct, ['lat', 'lon'], weights=wgt) 
 
    # probabilistic
    obs = xr.DataArray(

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -6,14 +6,62 @@ from.np_deterministic import _pearson_r, _pearson_r_p_value, _rmse, _mse, _mae
 __all__ = ['pearson_r', 'pearson_r_p_value', 'rmse', 'mse', 'mae']
 
 
-def _preprocess(dim):
+# NOTE: Currently xskillscore doesn't test for xarray datasets or dataarrays but
+# leverages all xarray functions despite saying it takes numpy arrays.
+def _preprocess_dims(dim):
+    """Preprocesses dimensions to prep for stacking.
+    
+    Parameters
+    ----------
+    dim : str, list
+        The dimension(s) to apply the function along.
+    """
     if isinstance(dim, str):
         dim = [dim]
     axis = tuple(range(-1, -len(dim) - 1, -1))
     return dim, axis
 
 
-def pearson_r(a, b, dim):
+def _preprocess_weights(a, dim, new_dim, weights):
+    """Preprocesses weights array to prepare for numpy computation.
+    
+    Parameters
+    ----------
+    a : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
+        One of the arrays over which the function will be applied.
+    dim : str, list
+        The original dimension(s) to apply the function along.
+    new_dim : str
+        The newly named dimension after running ``_preprocess_dims``
+    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
+        Weights to apply to function, matching the dimension size of ``new_dim``.
+    """
+    if weights is None:
+        weights = xr.ones_like(a)  # Evenly weight
+    else:
+        # Scale weights to vary from 0 to 1.
+        weights = weights / weights.max()
+        # Throw error if there are negative weights.
+        if weights.min() < 0:
+            raise ValueError(
+                f"Weights has a minimum below 0. Please submit a weights array "
+                f"of positive numbers."
+                )
+        # Check that the weights array has the same size
+        # dimension(s) as that being applied over.
+        drop_dims = [i for i in a.dims if i not in new_dim]
+        drop_dims = {k: 0 for k in drop_dims}
+        if dict(weights.sizes) != dict(a.isel(drop_dims).sizes):
+            raise ValueError(
+                f"weights dimension(s) {dim} of size {dict(weights.sizes)} "
+                f"does not match DataArray's size {dict(a.isel(drop_dims).sizes)}"
+                )
+        if dict(weights.sizes) != dict(a.sizes):
+            _, weights = xr.broadcast(a, weights)
+    return weights
+
+
+def pearson_r(a, b, dim, weights=None):
     """
     Pearson's correlation coefficient.
 
@@ -25,6 +73,9 @@ def pearson_r(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     dim : str, list
         The dimension(s) to apply the correlation along.
+    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
+        Weights matching dimensions of ``dim`` to apply during the function.
+        If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
@@ -38,22 +89,26 @@ def pearson_r(a, b, dim):
     xarray.apply_ufunc
 
     """
-    dim, _ = _preprocess(dim)
+    dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
         new_dim = '_'.join(dim)
         a = a.stack(**{new_dim: dim})
         b = b.stack(**{new_dim: dim})
+        if weights is not None:
+            weights = weights.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
+    weights = _preprocess_weights(a, dim, new_dim, weights)
 
-    return xr.apply_ufunc(_pearson_r, a, b,
-                          input_core_dims=[[new_dim], [new_dim]],
+
+    return xr.apply_ufunc(_pearson_r, a, b, weights,
+                          input_core_dims=[[new_dim], [new_dim], [new_dim]],
                           kwargs={'axis': -1},
                           dask='parallelized',
                           output_dtypes=[float])
 
 
-def pearson_r_p_value(a, b, dim):
+def pearson_r_p_value(a, b, dim, weights=None):
     """
     2-tailed p-value associated with pearson's correlation coefficient.
 
@@ -65,6 +120,9 @@ def pearson_r_p_value(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     dim : str, list
         The dimension(s) to apply the correlation along.
+    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
+        Weights matching dimensions of ``dim`` to apply during the function.
+        If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
@@ -78,22 +136,25 @@ def pearson_r_p_value(a, b, dim):
     xarray.apply_ufunc
 
     """
-    dim, _ = _preprocess(dim)
+    dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
         new_dim = '_'.join(dim)
         a = a.stack(**{new_dim: dim})
         b = b.stack(**{new_dim: dim})
+        if weights is not None:
+            weights = weights.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
+    weights = _preprocess_weights(a, dim, new_dim, weights)
 
-    return xr.apply_ufunc(_pearson_r_p_value, a, b,
-                          input_core_dims=[[new_dim], [new_dim]],
+    return xr.apply_ufunc(_pearson_r_p_value, a, b, weights,
+                          input_core_dims=[[new_dim], [new_dim], [new_dim]],
                           kwargs={'axis': -1},
                           dask='parallelized',
                           output_dtypes=[float])
 
 
-def rmse(a, b, dim):
+def rmse(a, b, dim, weights=None):
     """
     Root Mean Squared Error.
 
@@ -105,6 +166,9 @@ def rmse(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     dim : str, list
         The dimension(s) to apply the rmse along.
+    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
+        Weights matching dimensions of ``dim`` to apply during the function.
+        If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
@@ -118,16 +182,17 @@ def rmse(a, b, dim):
     xarray.apply_ufunc
 
     """
-    dim, axis = _preprocess(dim)
+    dim, axis = _preprocess_dims(dim)
+    weights = _preprocess_weights(a, dim, dim, weights)
 
-    return xr.apply_ufunc(_rmse, a, b,
-                          input_core_dims=[dim, dim],
+    return xr.apply_ufunc(_rmse, a, b, weights,
+                          input_core_dims=[dim, dim, dim],
                           kwargs={'axis': axis},
                           dask='parallelized',
                           output_dtypes=[float])
 
 
-def mse(a, b, dim):
+def mse(a, b, dim, weights=None):
     """
     Mean Squared Error.
 
@@ -139,6 +204,9 @@ def mse(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     dim : str, list
         The dimension(s) to apply the mse along.
+    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
+        Weights matching dimensions of ``dim`` to apply during the function.
+        If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
@@ -152,16 +220,17 @@ def mse(a, b, dim):
     xarray.apply_ufunc
 
     """
-    dim, axis = _preprocess(dim)
+    dim, axis = _preprocess_dims(dim)
+    weights = _preprocess_weights(a, dim, dim, weights)
 
-    return xr.apply_ufunc(_mse, a, b,
-                          input_core_dims=[dim, dim],
+    return xr.apply_ufunc(_mse, a, b, weights,
+                          input_core_dims=[dim, dim, dim],
                           kwargs={'axis': axis},
                           dask='parallelized',
                           output_dtypes=[float])
 
 
-def mae(a, b, dim):
+def mae(a, b, dim, weights=None):
     """
     Mean Absolute Error.
 
@@ -173,6 +242,9 @@ def mae(a, b, dim):
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     dim : str, list
         The dimension(s) to apply the mae along.
+    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
+        Weights matching dimensions of ``dim`` to apply during the function.
+        If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
@@ -186,10 +258,11 @@ def mae(a, b, dim):
     xarray.apply_ufunc
 
     """
-    dim, axis = _preprocess(dim)
+    dim, axis = _preprocess_dims(dim)
+    weights = _preprocess_weights(a, dim, dim, weights)
 
-    return xr.apply_ufunc(_mae, a, b,
-                          input_core_dims=[dim, dim],
+    return xr.apply_ufunc(_mae, a, b, weights,
+                          input_core_dims=[dim, dim, dim],
                           kwargs={'axis': axis},
                           dask='parallelized',
                           output_dtypes=[float])

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -25,14 +25,13 @@ def _preprocess_weights(a, dim, new_dim, weights):
 
     Parameters
     ----------
-    a : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
+    a : xarray.Dataset or xarray.DataArray
         One of the arrays over which the function will be applied.
     dim : str, list
         The original dimension(s) to apply the function along.
     new_dim : str
         The newly named dimension after running ``_preprocess_dims``
-    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-              scalars
+    weights : xarray.Dataset or xarray.DataArray
         Weights to apply to function, matching the dimension size of
         ``new_dim``.
     """
@@ -69,21 +68,19 @@ def pearson_r(a, b, dim, weights=None):
 
     Parameters
     ----------
-    a : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
-    b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
+    a : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
+    b : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
     dim : str, list
         The dimension(s) to apply the correlation along.
-    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-              scalars
+    weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-    numpy.ndarray, the first type on that list to appear on an input.
+    xr.DataArray or xr.Dataset
         Pearson's correlation coefficient.
 
     See Also
@@ -121,21 +118,19 @@ def pearson_r_p_value(a, b, dim, weights=None):
 
     Parameters
     ----------
-    a : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
-    b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
+    a : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
+    b : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
     dim : str, list
         The dimension(s) to apply the correlation along.
-    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-              scalars
+    weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-    numpy.ndarray, the first type on that list to appear on an input.
+    xarray.Dataset or xarray.DataArray
         2-tailed p-value.
 
     See Also
@@ -173,21 +168,19 @@ def rmse(a, b, dim, weights=None):
 
     Parameters
     ----------
-    a : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
-    b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
+    a : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
+    b : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
     dim : str, list
         The dimension(s) to apply the rmse along.
-    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-              scalars
+    weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-    numpy.ndarray, the first type on that list to appear on an input.
+    xarray.Dataset or xarray.DataArray
         Root Mean Squared Error.
 
     See Also
@@ -217,21 +210,19 @@ def mse(a, b, dim, weights=None):
 
     Parameters
     ----------
-    a : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
-    b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
+    a : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
+    b : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
     dim : str, list
         The dimension(s) to apply the mse along.
-    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-              scalars
+    weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-    numpy.ndarray, the first type on that list to appear on an input.
+    xarray.Dataset or xarray.DataArray
         Mean Squared Error.
 
     See Also
@@ -261,21 +252,19 @@ def mae(a, b, dim, weights=None):
 
     Parameters
     ----------
-    a : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
-    b : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
-        Mix of labeled and/or unlabeled arrays to which to apply the function.
+    a : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
+    b : xarray.Dataset or xarray.DataArray
+        Labeled array(s) over which to apply the function.
     dim : str, list
         The dimension(s) to apply the mae along.
-    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-              scalars
+    weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-    numpy.ndarray, the first type on that list to appear on an input.
+    xarray.Dataset or xarray.DataArray
         Mean Absolute Error.
 
     See Also

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -5,7 +5,7 @@ from scipy import special
 __all__ = ['_pearson_r', '_pearson_r_p_value', '_rmse', '_mse', '_mae']
 
 
-def _pearson_r(a, b, axis):
+def _pearson_r(a, b, weights, axis):
     """
     ndarray implementation of scipy.stats.pearsonr.
 
@@ -17,6 +17,8 @@ def _pearson_r(a, b, axis):
         Input array.
     axis : int
         The axis to apply the correlation along.
+    weights : ndarray
+        Input array.
 
     Returns
     -------
@@ -30,17 +32,18 @@ def _pearson_r(a, b, axis):
     """
     a = np.rollaxis(a, axis)
     b = np.rollaxis(b, axis)
-    ma = np.mean(a, axis=0)
-    mb = np.mean(b, axis=0)
+    weights = np.rollaxis(weights, axis)
+    ma = np.sum(a * weights, axis=0) / np.sum(weights, axis=0)
+    mb = np.sum(b * weights, axis=0) / np.sum(weights, axis=0)
     am, bm = a - ma, b - mb
-    r_num = np.sum(am * bm, axis=0)
-    r_den = np.sqrt(np.sum(am*am, axis=0) * np.sum(bm*bm, axis=0))
+    r_num = np.sum(weights * am * bm, axis=0)
+    r_den = np.sqrt(np.sum(weights * am * am, axis=0) * np.sum(weights * bm * bm, axis=0))
     r = r_num / r_den
     res = np.clip(r, -1.0, 1.0)
     return res
 
 
-def _pearson_r_p_value(a, b, axis):
+def _pearson_r_p_value(a, b, weights, axis):
     """
     ndarray implementation of scipy.stats.pearsonr.
 
@@ -52,6 +55,8 @@ def _pearson_r_p_value(a, b, axis):
         Input array.
     axis : int
         The axis to apply the correlation along.
+    weights : ndarray
+        Input array.
 
     Returns
     -------
@@ -63,7 +68,7 @@ def _pearson_r_p_value(a, b, axis):
     scipy.stats.pearsonr
 
     """
-    r = _pearson_r(a, b, axis)
+    r = _pearson_r(a, b, weights, axis)
     a = np.rollaxis(a, axis)
     df = a.shape[0] - 2
     t_squared = r**2 * (df / ((1.0 - r) * (1.0 + r)))
@@ -76,7 +81,7 @@ def _pearson_r_p_value(a, b, axis):
     return res
 
 
-def _rmse(a, b, axis):
+def _rmse(a, b, weights, axis):
     """
     Root Mean Squared Error.
 
@@ -88,6 +93,8 @@ def _rmse(a, b, axis):
         Input array.
     axis : int
         The axis to apply the rmse along.
+    weights : ndarray
+        Input array.
 
     Returns
     -------
@@ -99,11 +106,13 @@ def _rmse(a, b, axis):
     sklearn.metrics.mean_squared_error
 
     """
-    res = np.sqrt(((a - b) ** 2).mean(axis=axis))
+    squared_error = (a - b) ** 2
+    mean_squared_error = np.sum(squared_error * weights, axis=axis) / np.sum(weights, axis=axis)
+    res = np.sqrt(mean_squared_error)
     return res
 
 
-def _mse(a, b, axis):
+def _mse(a, b, weights, axis):
     """
     Mean Squared Error.
 
@@ -115,6 +124,8 @@ def _mse(a, b, axis):
         Input array.
     axis : int
         The axis to apply the mse along.
+    weights : ndarray
+        Input array.
 
     Returns
     -------
@@ -126,11 +137,12 @@ def _mse(a, b, axis):
     sklearn.metrics.mean_squared_error
 
     """
-    res = ((a - b) ** 2).mean(axis=axis)
+    squared_error = (a - b) **2
+    res = np.sum(squared_error * weights, axis=axis) / np.sum(weights, axis=axis)
     return res
 
 
-def _mae(a, b, axis):
+def _mae(a, b, weights, axis):
     """
     Mean Absolute Error.
 
@@ -142,6 +154,8 @@ def _mae(a, b, axis):
         Input array.
     axis : int
         The axis to apply the mae along.
+    weights : ndarray
+        Input array.
 
     Returns
     -------
@@ -153,5 +167,6 @@ def _mae(a, b, axis):
     sklearn.metrics.mean_absolute_error
 
     """
-    res = (np.absolute(a - b)).mean(axis=axis)
+    absolute_error = np.absolute(a - b)
+    res = np.sum(absolute_error * weights, axis=axis) / np.sum(weights, axis=axis)
     return res

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -2,7 +2,18 @@ import numpy as np
 from scipy import special
 
 
-__all__ = ['_pearson_r', '_pearson_r_p_value', '_rmse', '_mse', '_mae']
+__all__ = ["_pearson_r", "_pearson_r_p_value", "_rmse", "_mse", "_mae"]
+
+
+def _check_weights(weights):
+    """
+    Quick check if weights are all NaN. If so,
+    return None to guide weighting scheme.
+    """
+    if np.all(np.isnan(weights)):
+        return None
+    else:
+        return weights
 
 
 def _pearson_r(a, b, weights, axis):
@@ -30,14 +41,33 @@ def _pearson_r(a, b, weights, axis):
     scipy.stats.pearsonr
 
     """
+    weights = _check_weights(weights)
     a = np.rollaxis(a, axis)
     b = np.rollaxis(b, axis)
-    weights = np.rollaxis(weights, axis)
-    ma = np.sum(a * weights, axis=0) / np.sum(weights, axis=0)
-    mb = np.sum(b * weights, axis=0) / np.sum(weights, axis=0)
+
+    # Only do weighted sums if there are weights. Cannot have a
+    # single generic function with weights of all ones, because
+    # the denominator gets inflated when there are masked regions.
+    if weights is not None:
+        weights = np.rollaxis(weights, axis)
+        ma = np.sum(a * weights, axis=0) / np.sum(weights, axis=0)
+        mb = np.sum(b * weights, axis=0) / np.sum(weights, axis=0)
+    else:
+        ma = np.mean(a, axis=0)
+        mb = np.mean(b, axis=0)
+
     am, bm = a - ma, b - mb
-    r_num = np.sum(weights * am * bm, axis=0)
-    r_den = np.sqrt(np.sum(weights * am * am, axis=0) * np.sum(weights * bm * bm, axis=0))
+
+    if weights is not None:
+        r_num = np.sum(weights * am * bm, axis=0)
+        r_den = np.sqrt(
+            np.sum(weights * am * am, axis=0)
+            * np.sum(weights * bm * bm, axis=0)
+        )
+    else:
+        r_num = np.sum(am * bm, axis=0)
+        r_den = np.sqrt(np.sum(am * am, axis=0) * np.sum(bm * bm, axis=0))
+
     r = r_num / r_den
     res = np.clip(r, -1.0, 1.0)
     return res
@@ -71,11 +101,11 @@ def _pearson_r_p_value(a, b, weights, axis):
     r = _pearson_r(a, b, weights, axis)
     a = np.rollaxis(a, axis)
     df = a.shape[0] - 2
-    t_squared = r**2 * (df / ((1.0 - r) * (1.0 + r)))
-    _x = df/(df+t_squared)
+    t_squared = r ** 2 * (df / ((1.0 - r) * (1.0 + r)))
+    _x = df / (df + t_squared)
     _x = np.asarray(_x)
     _x = np.where(_x < 1.0, _x, 1.0)
-    _a = 0.5*df
+    _a = 0.5 * df
     _b = 0.5
     res = special.betainc(_a, _b, _x)
     return res
@@ -106,8 +136,15 @@ def _rmse(a, b, weights, axis):
     sklearn.metrics.mean_squared_error
 
     """
+    weights = _check_weights(weights)
+
     squared_error = (a - b) ** 2
-    mean_squared_error = np.sum(squared_error * weights, axis=axis) / np.sum(weights, axis=axis)
+    if weights is not None:
+        mean_squared_error = np.sum(
+            squared_error * weights, axis=axis
+        ) / np.sum(weights, axis=axis)
+    else:
+        mean_squared_error = ((a - b) ** 2).mean(axis=axis)
     res = np.sqrt(mean_squared_error)
     return res
 
@@ -137,9 +174,15 @@ def _mse(a, b, weights, axis):
     sklearn.metrics.mean_squared_error
 
     """
-    squared_error = (a - b) **2
-    res = np.sum(squared_error * weights, axis=axis) / np.sum(weights, axis=axis)
-    return res
+    weights = _check_weights(weights)
+
+    squared_error = (a - b) ** 2
+    if weights is not None:
+        return np.sum(squared_error * weights, axis=axis) / np.sum(
+            weights, axis=axis
+        )
+    else:
+        return squared_error.mean(axis=axis)
 
 
 def _mae(a, b, weights, axis):
@@ -167,6 +210,12 @@ def _mae(a, b, weights, axis):
     sklearn.metrics.mean_absolute_error
 
     """
+    weights = _check_weights(weights)
+
     absolute_error = np.absolute(a - b)
-    res = np.sum(absolute_error * weights, axis=axis) / np.sum(weights, axis=axis)
-    return res
+    if weights is not None:
+        return np.sum(absolute_error * weights, axis=axis) / np.sum(
+            weights, axis=axis
+        )
+    else:
+        return absolute_error.mean(axis=axis)

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -15,17 +15,16 @@ def xr_crps_gaussian(observations, mu, sig):
 
     Parameters
     ----------
-    observations : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled observations arrays.
-    mu : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled forecasts mean arrays.
-    sig : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled forecasts mean arrays.
+    observations : xarray.Dataset or xarray.DataArray
+        The observations or set of observations.
+    mu : xarray.Dataset or xarray.DataArray
+        The mean of the forecast normal distribution.
+    sig : xarray.Dataset or xarray.DataArray
+        The standard deviation of the forecast distribution.
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-     numpy.ndarray, the first type on that list to appear on an input.
+    xarray.Dataset or xarray.DataArray
 
     See Also
     --------
@@ -58,13 +57,15 @@ def xr_crps_quadrature(x, cdf_or_dist, xmin=None, xmax=None, tol=1e-6):
 
     Parameters
     ----------
-    x : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled x arrays.
+    x : xarray.Dataset or xarray.DataArray
+        Observations associated with the forecast distribution ``cdf_or_dist``.
+    cdf_or_dist : callable or scipy.stats.distribution
+        Function which returns the cumulative density of the forecast
+        distribution at value x.
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-     numpy.ndarray, the first type on that list to appear on an input.
+    xarray.Dataset or xarray.DataArray
 
     See Also
     --------
@@ -92,27 +93,24 @@ def xr_crps_ensemble(
 
     Parameters
     ----------
-    observations : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled observations arrays.
-    forecasts : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled forecasts arrays with required
-     member dimension `dim`.
-    weights : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled, optional
-     If provided, the CRPS is calculated exactly with the assigned
-     probability weights to each forecast. Weights should be positive, but
-     do not need to be normalized. By default, each forecast is weighted
-     equally.
+    observations : xarray.Dataset or xarray.DataArray
+        The observations or set of observations.
+    forecasts : xarray.Dataset or xarray.DataArray
+        Forecast with required member dimension ``dim``.
+    weights : xarray.Dataset or xarray.DataArray
+        If provided, the CRPS is calculated exactly with the assigned
+        probability weights to each forecast. Weights should be positive,
+        but do not need to be normalized. By default, each forecast is
+        weighted equally.
     issorted : bool, optional
-     Optimization flag to indicate that the elements of `ensemble` are
-     already sorted along `axis`.
+        Optimization flag to indicate that the elements of `ensemble` are
+        already sorted along `axis`.
     dim : str, optional
-     Name of ensemble member dimension. By default, 'member'.
+        Name of ensemble member dimension. By default, 'member'.
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-    numpy.ndarray, the first type on that list to appear on an input.
+    xarray.Dataset or xarray.DataArray
 
     See Also
     --------
@@ -133,20 +131,20 @@ def xr_crps_ensemble(
 def xr_brier_score(observations, forecasts):
     """
     xarray version of properscoring.brier_score: Calculate Brier score (BS).
+
     ..math:
         BS(p, k) = (p_1 - k)^2,
 
     Parameters
     ----------
-    observations : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled observations arrays.
-    forecasts : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled forecasts arrays.
+    observations : xarray.Dataset or xarray.DataArray
+        The observations or set of observations.
+    forecasts : xarray.Dataset or xarray.DataArray
+        The forecasts associated with the observations.
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-    numpy.ndarray, the first type on that list to appear on an input.
+    xarray.Dataset or xarray.DataArray
 
     References
     ----------
@@ -179,26 +177,24 @@ def xr_threshold_brier_score(
 
     Parameters
     ----------
-    observations : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled observations arrays.
-    forecasts : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or
-     scalars, Mix of labeled and/or unlabeled forecasts arrays with required
-     member dimension `dim`.
-    threshold : scalar or 1d scalar threshold values at
-     which to calculate exceedence Brier scores.
+    observations : xarray.Dataset or xarray.DataArray
+        The observations or set of observations.
+    forecasts : xarray.Dataset or xarray.DataArray
+        Forecast with required member dimension ``dim``.
+    threshold : scalar or 1d scalar
+        Threshold values at which to calculate exceedence Brier scores.
     issorted : bool, optional
         Optimization flag to indicate that the elements of `ensemble` are
         already sorted along `axis`.
     dim : str, optional
-     Name of ensemble member dimension. By default, 'member'.
+        Name of ensemble member dimension. By default, 'member'.
 
     Returns
     -------
-    Single value or tuple of Dataset, DataArray, Variable, dask.array.Array or
-    numpy.ndarray, the first type on that list to appear on an input. (If
-    ``threshold`` is a scalar, the result will have the same shape as
-    observations. Otherwise, it will have an additional final dimension
-    corresponding to the threshold levels. Not implemented yet.)
+    xarray.Dataset or xarray.DataArray
+        (If ``threshold`` is a scalar, the result will have the same shape as
+        observations. Otherwise, it will have an additional final dimension
+        corresponding to the threshold levels. Not implemented yet.)
 
     References
     ----------

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -5,259 +5,341 @@ import xarray as xr
 from xarray.tests import assert_allclose
 
 from xskillscore.core.deterministic import (
-    _preprocess_dims, mae, mse, pearson_r, pearson_r_p_value, rmse)
+    _preprocess_dims,
+    _preprocess_weights,
+    mae,
+    mse,
+    pearson_r,
+    pearson_r_p_value,
+    rmse,
+)
 from xskillscore.core.np_deterministic import (
-    _mae, _mse, _pearson_r, _pearson_r_p_value, _rmse)
+    _mae,
+    _mse,
+    _pearson_r,
+    _pearson_r_p_value,
+    _rmse,
+)
 
 
-AXES = ('time', 'lat', 'lon', ('lat', 'lon'))
+AXES = ("time", "lat", "lon", ("lat", "lon"), ("time", "lat", "lon"))
 
 
 @pytest.fixture
 def a():
-    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)
     lons = np.arange(5)
     data = np.random.rand(len(dates), len(lats), len(lons))
-    return xr.DataArray(data,
-                        coords=[dates, lats, lons],
-                        dims=['time', 'lat', 'lon'])
+    return xr.DataArray(data, coords=[dates, lats, lons], dims=["time", "lat", "lon"])
 
 
 @pytest.fixture
 def b():
-    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)
     lons = np.arange(5)
     data = np.random.rand(len(dates), len(lats), len(lons))
-    return xr.DataArray(data,
-                        coords=[dates, lats, lons],
-                        dims=['time', 'lat', 'lon'])
+    return xr.DataArray(data, coords=[dates, lats, lons], dims=["time", "lat", "lon"])
 
 
 @pytest.fixture
-def weights_ones():
-    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+def weights():
+    """
+    Weighting array by cosine of the latitude.
+    """
+    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)
     lons = np.arange(5)
-    data = np.ones((len(dates), len(lats), len(lons)))
-    return xr.DataArray(data,
-                        coords=[dates, lats, lons],
-                        dims=['time', 'lat', 'lon'])
+    cos = np.abs(np.cos(lats))
+    data = np.tile(cos, (len(dates), len(lons), 1)).reshape(
+        len(dates), len(lats), len(lons)
+    )
+    return xr.DataArray(data, coords=[dates, lats, lons], dims=["time", "lat", "lon"])
+
+
+@pytest.fixture
+def weights_dask():
+    """
+    Weighting array by cosine of the latitude.
+    """
+    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
+    lats = np.arange(4)
+    lons = np.arange(5)
+    cos = np.abs(np.cos(lats))
+    data = np.tile(cos, (len(dates), len(lons), 1)).reshape(
+        len(dates), len(lats), len(lons)
+    )
+    return xr.DataArray(
+        data, coords=[dates, lats, lons], dims=["time", "lat", "lon"]
+    ).chunk()
 
 
 @pytest.fixture
 def a_dask():
-    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)
     lons = np.arange(5)
     data = np.random.rand(len(dates), len(lats), len(lons))
-    return xr.DataArray(data,
-                        coords=[dates, lats, lons],
-                        dims=['time', 'lat', 'lon']).chunk()
+    return xr.DataArray(
+        data, coords=[dates, lats, lons], dims=["time", "lat", "lon"]
+    ).chunk()
 
 
 @pytest.fixture
 def b_dask(b):
-    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)
     lons = np.arange(5)
     data = np.random.rand(len(dates), len(lats), len(lons))
-    return xr.DataArray(data,
-                        coords=[dates, lats, lons],
-                        dims=['time', 'lat', 'lon']).chunk()
+    return xr.DataArray(
+        data, coords=[dates, lats, lons], dims=["time", "lat", "lon"]
+    ).chunk()
 
 
-@pytest.fixture
-def weights_ones_dask(b):
-    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
-    lats = np.arange(4)
-    lons = np.arange(5)
-    data = np.ones((len(dates), len(lats), len(lons)))
-    return xr.DataArray(data,
-                        coords=[dates, lats, lons],
-                        dims=['time', 'lat', 'lon']).chunk()
+def adjust_weights(dim, weight, weights):
+    """
+    Adjust the weights test data to only span the core dimension
+    that the function is being applied over.
+    """
+    if weight:
+        drop_dims = [i for i in weights.dims if i not in dim]
+        drop_dims = {k: 0 for k in drop_dims}
+        return weights.isel(drop_dims)
+    else:
+        return None
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_pearson_r_xr(a, b, dim, weights_ones):
-    actual = pearson_r(a, b, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_pearson_r_xr(a, b, dim, weight, weights):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    _weights = adjust_weights(dim, weight, weights)
+
+    actual = pearson_r(a, b, dim, weights=_weights)
     assert actual.chunks is None
 
     dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
-        new_dim = '_'.join(dim)
+        new_dim = "_".join(dim)
         _a = a.stack(**{new_dim: dim})
         _b = b.stack(**{new_dim: dim})
-        _weights_ones = weights_ones.stack(**{new_dim: dim})
+        if weight:
+            _weights = _weights.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
         _a = a
         _b = b
-        _weights_ones = weights_ones
+    _weights = _preprocess_weights(_a, dim, new_dim, _weights)
 
     axis = _a.dims.index(new_dim)
-    res = _pearson_r(_a.values, _b.values, _weights_ones.values, axis)
+    res = _pearson_r(_a.values, _b.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_pearson_r_xr_dask(a_dask, b_dask, dim, weights_ones_dask):
-    actual = pearson_r(a_dask, b_dask, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_pearson_r_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    _weights = adjust_weights(dim, weight, weights_dask)
+
+    actual = pearson_r(a_dask, b_dask, dim, weights=_weights)
     assert actual.chunks is not None
 
     dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
-        new_dim = '_'.join(dim)
+        new_dim = "_".join(dim)
         _a_dask = a_dask.stack(**{new_dim: dim})
         _b_dask = b_dask.stack(**{new_dim: dim})
-        _weights_ones_dask = weights_ones_dask.stack(**{new_dim: dim})
+        if weight:
+            _weights = _weights.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
         _a_dask = a_dask
         _b_dask = b_dask
-        _weights_ones_dask = weights_ones_dask
+    _weights = _preprocess_weights(_a_dask, dim, new_dim, _weights)
 
     axis = _a_dask.dims.index(new_dim)
-    res = _pearson_r(_a_dask.values, _b_dask.values, _weights_ones_dask.values, axis)
+    res = _pearson_r(_a_dask.values, _b_dask.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_pearson_r_p_value_xr(a, b, dim, weights_ones):
-    actual = pearson_r_p_value(a, b, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_pearson_r_p_value_xr(a, b, dim, weight, weights):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    _weights = adjust_weights(dim, weight, weights)
+
+    actual = pearson_r_p_value(a, b, dim, weights=_weights)
     assert actual.chunks is None
 
     dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
-        new_dim = '_'.join(dim)
+        new_dim = "_".join(dim)
         _a = a.stack(**{new_dim: dim})
         _b = b.stack(**{new_dim: dim})
-        _weights_ones = weights_ones.stack(**{new_dim: dim})
+        if weight:
+            _weights = _weights.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
         _a = a
         _b = b
-        _weights_ones = weights_ones
+    _weights = _preprocess_weights(_a, dim, new_dim, _weights)
 
     axis = _a.dims.index(new_dim)
-    res = _pearson_r_p_value(_a.values, _b.values, _weights_ones.values, axis)
+    res = _pearson_r_p_value(_a.values, _b.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim, weights_ones_dask):
-    actual = pearson_r_p_value(a_dask, b_dask, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    _weights = adjust_weights(dim, weight, weights_dask)
+
+    actual = pearson_r_p_value(a_dask, b_dask, dim, weights=_weights)
     assert actual.chunks is not None
 
     dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
-        new_dim = '_'.join(dim)
+        new_dim = "_".join(dim)
         _a_dask = a_dask.stack(**{new_dim: dim})
         _b_dask = b_dask.stack(**{new_dim: dim})
-        _weights_ones_dask = weights_ones_dask.stack(**{new_dim: dim})
+        if weight:
+            _weights = _weights.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
         _a_dask = a_dask
         _b_dask = b_dask
-        _weights_ones_dask = weights_ones_dask
+    _weights = _preprocess_weights(_a_dask, dim, new_dim, _weights)
 
     axis = _a_dask.dims.index(new_dim)
-    res = _pearson_r_p_value(_a_dask.values, _b_dask.values, _weights_ones_dask.values, axis)
+    res = _pearson_r_p_value(_a_dask.values, _b_dask.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_rmse_r_xr(a, b, dim, weights_ones):
-    actual = rmse(a, b, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_rmse_xr(a, b, dim, weight, weights):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    weights = adjust_weights(dim, weight, weights)
+
+    actual = rmse(a, b, dim, weights=weights)
     assert actual.chunks is None
 
     dim, axis = _preprocess_dims(dim)
-    _a = a.values
-    _b = b.values
+    _a = a
+    _b = b
+    _weights = _preprocess_weights(_a, dim, dim, weights)
     axis = tuple(a.dims.index(d) for d in dim)
-    res = _rmse(_a, _b, weights_ones.values, axis)
+    res = _rmse(_a.values, _b.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_rmse_r_xr_dask(a_dask, b_dask, dim, weights_ones):
-    actual = rmse(a_dask, b_dask, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_rmse_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    _weights = adjust_weights(dim, weight, weights_dask)
+
+    actual = rmse(a_dask, b_dask, dim, weights=_weights)
     assert actual.chunks is not None
 
     dim, axis = _preprocess_dims(dim)
-    _a_dask = a_dask.values
-    _b_dask = b_dask.values
+    _a_dask = a_dask
+    _b_dask = b_dask
+    _weights = _preprocess_weights(_a_dask, dim, dim, _weights)
     axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _rmse(_a_dask, _b_dask, weights_ones.values, axis)
+    res = _rmse(_a_dask.values, _b_dask.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_mse_r_xr(a, b, dim, weights_ones):
-    actual = mse(a, b, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_mse_xr(a, b, dim, weight, weights):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    weights = adjust_weights(dim, weight, weights)
+
+    actual = mse(a, b, dim, weights=weights)
     assert actual.chunks is None
 
     dim, axis = _preprocess_dims(dim)
-    _a = a.values
-    _b = b.values
+    _a = a
+    _b = b
+    _weights = _preprocess_weights(_a, dim, dim, weights)
     axis = tuple(a.dims.index(d) for d in dim)
-    res = _mse(_a, _b, weights_ones.values, axis)
+    res = _mse(_a.values, _b.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_mse_r_xr_dask(a_dask, b_dask, dim, weights_ones):
-    actual = mse(a_dask, b_dask, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_mse_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    _weights = adjust_weights(dim, weight, weights_dask)
+
+    actual = mse(a_dask, b_dask, dim, weights=_weights)
     assert actual.chunks is not None
 
     dim, axis = _preprocess_dims(dim)
-    _a_dask = a_dask.values
-    _b_dask = b_dask.values
+    _a_dask = a_dask
+    _b_dask = b_dask
+    _weights = _preprocess_weights(_a_dask, dim, dim, _weights)
     axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _mse(_a_dask, _b_dask, weights_ones.values, axis)
+    res = _mse(_a_dask.values, _b_dask.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_mae_r_xr(a, b, dim, weights_ones):
-    actual = mae(a, b, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_mae_xr(a, b, dim, weight, weights):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    weights = adjust_weights(dim, weight, weights)
+
+    actual = mae(a, b, dim, weights=weights)
     assert actual.chunks is None
+
     dim, axis = _preprocess_dims(dim)
-    _a = a.values
-    _b = b.values
+    _a = a
+    _b = b
+    _weights = _preprocess_weights(_a, dim, dim, weights)
     axis = tuple(a.dims.index(d) for d in dim)
-    res = _mae(_a, _b, weights_ones.values, axis)
+    res = _mae(_a.values, _b.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize('dim', AXES)
-def test_mae_r_xr_dask(a_dask, b_dask, dim, weights_ones):
-    actual = mae(a_dask, b_dask, dim)
+@pytest.mark.parametrize("dim", AXES)
+@pytest.mark.parametrize("weight", [True, False])
+def test_mae_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
+    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    _weights = adjust_weights(dim, weight, weights_dask)
+    actual = mae(a_dask, b_dask, dim, weights=_weights)
     assert actual.chunks is not None
+
     dim, axis = _preprocess_dims(dim)
-    _a_dask = a_dask.values
-    _b_dask = b_dask.values
+    _a_dask = a_dask
+    _b_dask = b_dask
+    _weights = _preprocess_weights(_a_dask, dim, dim, _weights)
     axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _mae(_a_dask, _b_dask, weights_ones.values, axis)
+    res = _mae(_a_dask.values, _b_dask.values, _weights.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -5,7 +5,7 @@ import xarray as xr
 from xarray.tests import assert_allclose
 
 from xskillscore.core.deterministic import (
-    _preprocess, mae, mse, pearson_r, pearson_r_p_value, rmse)
+    _preprocess_dims, mae, mse, pearson_r, pearson_r_p_value, rmse)
 from xskillscore.core.np_deterministic import (
     _mae, _mse, _pearson_r, _pearson_r_p_value, _rmse)
 
@@ -36,6 +36,17 @@ def b():
 
 
 @pytest.fixture
+def weights_ones():
+    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+    lats = np.arange(4)
+    lons = np.arange(5)
+    data = np.ones((len(dates), len(lats), len(lons)))
+    return xr.DataArray(data,
+                        coords=[dates, lats, lons],
+                        dims=['time', 'lat', 'lon'])
+
+
+@pytest.fixture
 def a_dask():
     dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
     lats = np.arange(4)
@@ -57,177 +68,196 @@ def b_dask(b):
                         dims=['time', 'lat', 'lon']).chunk()
 
 
+@pytest.fixture
+def weights_ones_dask(b):
+    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+    lats = np.arange(4)
+    lons = np.arange(5)
+    data = np.ones((len(dates), len(lats), len(lons)))
+    return xr.DataArray(data,
+                        coords=[dates, lats, lons],
+                        dims=['time', 'lat', 'lon']).chunk()
+
+
 @pytest.mark.parametrize('dim', AXES)
-def test_pearson_r_xr(a, b, dim):
+def test_pearson_r_xr(a, b, dim, weights_ones):
     actual = pearson_r(a, b, dim)
     assert actual.chunks is None
 
-    dim, _ = _preprocess(dim)
+    dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
         new_dim = '_'.join(dim)
         _a = a.stack(**{new_dim: dim})
         _b = b.stack(**{new_dim: dim})
+        _weights_ones = weights_ones.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
         _a = a
         _b = b
+        _weights_ones = weights_ones
 
     axis = _a.dims.index(new_dim)
-    res = _pearson_r(_a.values, _b.values, axis)
+    res = _pearson_r(_a.values, _b.values, _weights_ones.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
-def test_pearson_r_xr_dask(a_dask, b_dask, dim):
+def test_pearson_r_xr_dask(a_dask, b_dask, dim, weights_ones_dask):
     actual = pearson_r(a_dask, b_dask, dim)
     assert actual.chunks is not None
 
-    dim, _ = _preprocess(dim)
+    dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
         new_dim = '_'.join(dim)
         _a_dask = a_dask.stack(**{new_dim: dim})
         _b_dask = b_dask.stack(**{new_dim: dim})
+        _weights_ones_dask = weights_ones_dask.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
         _a_dask = a_dask
         _b_dask = b_dask
+        _weights_ones_dask = weights_ones_dask
 
     axis = _a_dask.dims.index(new_dim)
-    res = _pearson_r(_a_dask.values, _b_dask.values, axis)
+    res = _pearson_r(_a_dask.values, _b_dask.values, _weights_ones_dask.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
-def test_pearson_r_p_value_xr(a, b, dim):
+def test_pearson_r_p_value_xr(a, b, dim, weights_ones):
     actual = pearson_r_p_value(a, b, dim)
     assert actual.chunks is None
 
-    dim, _ = _preprocess(dim)
+    dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
         new_dim = '_'.join(dim)
         _a = a.stack(**{new_dim: dim})
         _b = b.stack(**{new_dim: dim})
+        _weights_ones = weights_ones.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
         _a = a
         _b = b
+        _weights_ones = weights_ones
 
     axis = _a.dims.index(new_dim)
-    res = _pearson_r_p_value(_a.values, _b.values, axis)
+    res = _pearson_r_p_value(_a.values, _b.values, _weights_ones.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
-def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim):
+def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim, weights_ones_dask):
     actual = pearson_r_p_value(a_dask, b_dask, dim)
     assert actual.chunks is not None
 
-    dim, _ = _preprocess(dim)
+    dim, _ = _preprocess_dims(dim)
     if len(dim) > 1:
         new_dim = '_'.join(dim)
         _a_dask = a_dask.stack(**{new_dim: dim})
         _b_dask = b_dask.stack(**{new_dim: dim})
+        _weights_ones_dask = weights_ones_dask.stack(**{new_dim: dim})
     else:
         new_dim = dim[0]
         _a_dask = a_dask
         _b_dask = b_dask
+        _weights_ones_dask = weights_ones_dask
 
     axis = _a_dask.dims.index(new_dim)
-    res = _pearson_r_p_value(_a_dask.values, _b_dask.values, axis)
+    res = _pearson_r_p_value(_a_dask.values, _b_dask.values, _weights_ones_dask.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
-def test_rmse_r_xr(a, b, dim):
+def test_rmse_r_xr(a, b, dim, weights_ones):
     actual = rmse(a, b, dim)
     assert actual.chunks is None
 
-    dim, axis = _preprocess(dim)
+    dim, axis = _preprocess_dims(dim)
     _a = a.values
     _b = b.values
     axis = tuple(a.dims.index(d) for d in dim)
-    res = _rmse(_a, _b, axis)
+    res = _rmse(_a, _b, weights_ones.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
-def test_rmse_r_xr_dask(a_dask, b_dask, dim):
+def test_rmse_r_xr_dask(a_dask, b_dask, dim, weights_ones):
     actual = rmse(a_dask, b_dask, dim)
     assert actual.chunks is not None
 
-    dim, axis = _preprocess(dim)
+    dim, axis = _preprocess_dims(dim)
     _a_dask = a_dask.values
     _b_dask = b_dask.values
     axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _rmse(_a_dask, _b_dask, axis)
+    res = _rmse(_a_dask, _b_dask, weights_ones.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
-def test_mse_r_xr(a, b, dim):
+def test_mse_r_xr(a, b, dim, weights_ones):
     actual = mse(a, b, dim)
     assert actual.chunks is None
 
-    dim, axis = _preprocess(dim)
+    dim, axis = _preprocess_dims(dim)
     _a = a.values
     _b = b.values
     axis = tuple(a.dims.index(d) for d in dim)
-    res = _mse(_a, _b, axis)
+    res = _mse(_a, _b, weights_ones.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
-def test_mse_r_xr_dask(a_dask, b_dask, dim):
+def test_mse_r_xr_dask(a_dask, b_dask, dim, weights_ones):
     actual = mse(a_dask, b_dask, dim)
     assert actual.chunks is not None
 
-    dim, axis = _preprocess(dim)
+    dim, axis = _preprocess_dims(dim)
     _a_dask = a_dask.values
     _b_dask = b_dask.values
     axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _mse(_a_dask, _b_dask, axis)
+    res = _mse(_a_dask, _b_dask, weights_ones.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
-def test_mae_r_xr(a, b, dim):
+def test_mae_r_xr(a, b, dim, weights_ones):
     actual = mae(a, b, dim)
     assert actual.chunks is None
-    dim, axis = _preprocess(dim)
+    dim, axis = _preprocess_dims(dim)
     _a = a.values
     _b = b.values
     axis = tuple(a.dims.index(d) for d in dim)
-    res = _mae(_a, _b, axis)
+    res = _mae(_a, _b, weights_ones.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('dim', AXES)
-def test_mae_r_xr_dask(a_dask, b_dask, dim):
+def test_mae_r_xr_dask(a_dask, b_dask, dim, weights_ones):
     actual = mae(a_dask, b_dask, dim)
     assert actual.chunks is not None
-    dim, axis = _preprocess(dim)
+    dim, axis = _preprocess_dims(dim)
     _a_dask = a_dask.values
     _b_dask = b_dask.values
     axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _mae(_a_dask, _b_dask, axis)
+    res = _mae(_a_dask, _b_dask, weights_ones.values, axis)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)


### PR DESCRIPTION
Addresses https://github.com/raybellwaves/xskillscore/issues/27, https://github.com/raybellwaves/xskillscore/issues/16.

* Adds `weights` keyword to all deterministic functions
* Adds testing for `weights` for all deterministic functions
* Expands documentation and commenting

CC @brian-rose, @hdrake