### PR TITLE
Add `skipna` option on high-level functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,17 +83,33 @@ Examples
    # You can weight over the dimensions the function is being applied
    # to by passing the argument ``weights=weight`` with a xr.DataArray
    # containing the dimension(s) being reduced.
-   cos = np.abs(np.cos(np.arange(4)))
-   wgts = np.tile(cos, (5, 1)).reshape(4, 5)
-   wgt = xr.DataArray(
-      wgts,
-      coords=[
-         np.arange(4),
-         np.arange(5),
-      ],
-      dims=["lat", "lon"],
-   )
-   rmse_wgt = xs.rmse(obs, fct, ['lat', 'lon'], weights=wgt) 
+   #
+   # This is a common practice when working with observations and model
+   # simulations of the Earth system. When working with rectilinear grids,
+   # one can weight the data by the cosine of the latitude, which is maximum
+   # at the equator and minimum at the poles (as in the below example). More
+   # complicated model grids tend to be accompanied by a cell area coordinate,
+   # which could also be passed into this function.
+   dims = ('lat', 'lon')
+   base_data = np.ones((30,180,360))
+   a = xr.DataArray(base_data + np.random.rand(30,180,360), dims=['time','lat', 'lon'])
+   b = xr.DataArray(base_data + np.random.rand(30,180,360), dims=['time','lat', 'lon'])
+   x = np.linspace(-179.5, 179.5, 360)
+   y = np.linspace(-89.5, 89.5, 180)
+   lon, lat = np.meshgrid(x, y)
+   a['latitude'] = (dims, lat)
+   a['longitude'] = (dims, lon)
+   b['latitude'] = (dims, lat)
+   b['longitude'] = (dims, lon)
+
+   # make weights
+   weights = np.cos(np.deg2rad(a.latitude))
+   a, weights = xr.broadcast(a, weights)
+   weights = weights.isel(time=0) # remove time from weights
+
+   # example
+   weighted = xs.pearson_r(a, b, dims, weights=weights)
+   non_weighted = xs.pearson_r(a, b, dims, weights=None)
 
    # probabilistic
    obs = xr.DataArray(

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,24 @@ Examples
    weighted = xs.pearson_r(a, b, dims, weights=weights)
    non_weighted = xs.pearson_r(a, b, dims, weights=None)
 
+   # You can also pass the optional keyword `skipna=True` to ignore any NaNs on the
+   # input data. This is useful in the case that you are computing these functions
+   # over space and have a mask applied to the grid or have NaNs over land.
+
+   skipna_res = xs.mae(obs.where(obs.lat > 1), fct.where(fct.lat > 1), ['lat', 'lon'], skipna=True)
+   # >>> skipna_res
+   # <xarray.DataArray (time: 3)>
+   # array([0.29007757, 0.29660133, 0.38978561])
+   # Coordinates:
+   # * time     (time) datetime64[ns] 2000-01-01 2000-01-02 2000-01-03
+
+   no_skipna_res = xs.mae(obs.where(obs.lat > 1), fct.where(fct.lat > 1), ['lat', 'lon'], skipna=False)
+   # >>> no_skipna_res
+   # <xarray.DataArray (time: 3)>
+   # array([nan, nan, nan])
+   # Coordinates:
+   # * time     (time) datetime64[ns] 2000-01-01 2000-01-02 2000-01-03
+
    # probabilistic
    obs = xr.DataArray(
        np.random.rand(4, 5),

--- a/README.rst
+++ b/README.rst
@@ -91,9 +91,15 @@ Examples
    # complicated model grids tend to be accompanied by a cell area coordinate,
    # which could also be passed into this function.
    dims = ('lat', 'lon')
-   base_data = np.ones((30,180,360))
-   a = xr.DataArray(base_data + np.random.rand(30,180,360), dims=['time','lat', 'lon'])
-   b = xr.DataArray(base_data + np.random.rand(30,180,360), dims=['time','lat', 'lon'])
+   base_data = np.ones((30, 180, 360))
+   a = xr.DataArray(
+       base_data + np.random.rand(30, 180, 360),
+       dims=['time', 'lat', 'lon']
+   )
+   b = xr.DataArray(
+       base_data + np.random.rand(30, 180, 360),
+       dims=['time', 'lat', 'lon']
+   )
    x = np.linspace(-179.5, 179.5, 360)
    y = np.linspace(-89.5, 89.5, 180)
    lon, lat = np.meshgrid(x, y)

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -38,18 +38,17 @@ def _preprocess_weights(a, dim, new_dim, weights):
     if weights is None:
         return xr.full_like(a, None)  # Return nan weighting array.
     else:
-        # Scale weights to vary from 0 to 1.
-        weights = weights / weights.max()
         # Throw error if there are negative weights.
         if weights.min() < 0:
             raise ValueError(
                 "Weights has a minimum below 0. Please submit a weights array "
                 "of positive numbers."
             )
+        # Scale weights to vary from 0 to 1.
+        weights = weights / weights.max()
         # Check that the weights array has the same size
         # dimension(s) as those being applied over.
-        drop_dims = [i for i in a.dims if i not in new_dim]
-        drop_dims = {k: 0 for k in drop_dims}
+        drop_dims = {k: 0 for k in a.dims if k not in new_dim}
         if dict(weights.sizes) != dict(a.isel(drop_dims).sizes):
             raise ValueError(
                 f"weights dimension(s) {dim} of size {dict(weights.sizes)} "
@@ -82,7 +81,7 @@ def pearson_r(a, b, dim, weights=None, skipna=False):
 
     Returns
     -------
-    xr.DataArray or xr.Dataset
+    xarray.DataArray or xarray.Dataset
         Pearson's correlation coefficient.
 
     See Also

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -62,7 +62,7 @@ def _preprocess_weights(a, dim, new_dim, weights):
         return weights
 
 
-def pearson_r(a, b, dim, weights=None):
+def pearson_r(a, b, dim, weights=None, skipna=False):
     """
     Pearson's correlation coefficient.
 
@@ -77,6 +77,8 @@ def pearson_r(a, b, dim, weights=None):
     weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
+    skipna : bool
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -106,13 +108,13 @@ def pearson_r(a, b, dim, weights=None):
         b,
         weights,
         input_core_dims=[[new_dim], [new_dim], [new_dim]],
-        kwargs={"axis": -1},
+        kwargs={"axis": -1, "skipna": skipna},
         dask="parallelized",
         output_dtypes=[float],
     )
 
 
-def pearson_r_p_value(a, b, dim, weights=None):
+def pearson_r_p_value(a, b, dim, weights=None, skipna=False):
     """
     2-tailed p-value associated with pearson's correlation coefficient.
 
@@ -127,6 +129,8 @@ def pearson_r_p_value(a, b, dim, weights=None):
     weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
+    skipna : bool
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -156,13 +160,13 @@ def pearson_r_p_value(a, b, dim, weights=None):
         b,
         weights,
         input_core_dims=[[new_dim], [new_dim], [new_dim]],
-        kwargs={"axis": -1},
+        kwargs={"axis": -1, "skipna": skipna},
         dask="parallelized",
         output_dtypes=[float],
     )
 
 
-def rmse(a, b, dim, weights=None):
+def rmse(a, b, dim, weights=None, skipna=False):
     """
     Root Mean Squared Error.
 
@@ -177,6 +181,8 @@ def rmse(a, b, dim, weights=None):
     weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
+    skipna : bool
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -198,13 +204,13 @@ def rmse(a, b, dim, weights=None):
         b,
         weights,
         input_core_dims=[dim, dim, dim],
-        kwargs={"axis": axis},
+        kwargs={"axis": axis, "skipna": skipna},
         dask="parallelized",
         output_dtypes=[float],
     )
 
 
-def mse(a, b, dim, weights=None):
+def mse(a, b, dim, weights=None, skipna=False):
     """
     Mean Squared Error.
 
@@ -219,6 +225,8 @@ def mse(a, b, dim, weights=None):
     weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
+    skipna : bool
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -240,13 +248,13 @@ def mse(a, b, dim, weights=None):
         b,
         weights,
         input_core_dims=[dim, dim, dim],
-        kwargs={"axis": axis},
+        kwargs={"axis": axis, "skipna": skipna},
         dask="parallelized",
         output_dtypes=[float],
     )
 
 
-def mae(a, b, dim, weights=None):
+def mae(a, b, dim, weights=None, skipna=False):
     """
     Mean Absolute Error.
 
@@ -261,6 +269,8 @@ def mae(a, b, dim, weights=None):
     weights : xarray.Dataset or xarray.DataArray
         Weights matching dimensions of ``dim`` to apply during the function.
         If None, an array of ones will be applied (i.e., no weighting).
+    skipna : bool
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -282,7 +292,7 @@ def mae(a, b, dim, weights=None):
         b,
         weights,
         input_core_dims=[dim, dim, dim],
-        kwargs={"axis": axis},
+        kwargs={"axis": axis, "skipna": skipna},
         dask="parallelized",
         output_dtypes=[float],
     )

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -5,17 +5,6 @@ from scipy import special
 __all__ = ["_pearson_r", "_pearson_r_p_value", "_rmse", "_mse", "_mae"]
 
 
-def _check_weights(weights):
-    """
-    Quick check if weights are all NaN. If so,
-    return None to guide weighting scheme.
-    """
-    if np.all(np.isnan(weights)):
-        return None
-    else:
-        return weights
-
-
 def _get_numpy_funcs(skipna):
     """
     Returns nansum and nanmean if skipna is True;
@@ -38,7 +27,7 @@ def _check_weights(weights):
         return weights
 
 
-def _pearson_r(a, b, weights, axis):
+def _pearson_r(a, b, weights, axis, skipna):
     """
     ndarray implementation of scipy.stats.pearsonr.
 
@@ -51,9 +40,9 @@ def _pearson_r(a, b, weights, axis):
     axis : int
         The axis to apply the correlation along.
     weights : ndarray
-        Input array.
+        Input array of weights for a and b.
     skipna : bool
-        Whether or not to skip NaNs.
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -86,8 +75,8 @@ def _pearson_r(a, b, weights, axis):
     if weights is not None:
         r_num = sumfunc(weights * am * bm, axis=0)
         r_den = np.sqrt(
-            np.sum(weights * am * am, axis=0)
-            * np.sum(weights * bm * bm, axis=0)
+            sumfunc(weights * am * am, axis=0)
+            * sumfunc(weights * bm * bm, axis=0)
         )
     else:
         r_num = sumfunc(am * bm, axis=0)
@@ -111,9 +100,9 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
     axis : int
         The axis to apply the correlation along.
     weights : ndarray
-        Input array.
+        Input array of weights for a and b.
     skipna : bool
-        Whether or not to skip NaNs.
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -151,9 +140,9 @@ def _rmse(a, b, weights, axis, skipna):
     axis : int
         The axis to apply the rmse along.
     weights : ndarray
-        Input array.
+        Input array of weights for a and b.
     skipna : bool
-        Whether or not to skip NaNs.
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -170,9 +159,9 @@ def _rmse(a, b, weights, axis, skipna):
 
     squared_error = (a - b) ** 2
     if weights is not None:
-        mean_squared_error = np.sum(
+        mean_squared_error = sumfunc(
             squared_error * weights, axis=axis
-        ) / np.sum(weights, axis=axis)
+        ) / sumfunc(weights, axis=axis)
     else:
         mean_squared_error = meanfunc(((a - b) ** 2), axis=axis)
     res = np.sqrt(mean_squared_error)
@@ -192,9 +181,9 @@ def _mse(a, b, weights, axis, skipna):
     axis : int
         The axis to apply the mse along.
     weights : ndarray
-        Input array.
+        Input array of weights for a and b.
     skipna : bool
-        Whether or not to skip NaNs.
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -211,7 +200,7 @@ def _mse(a, b, weights, axis, skipna):
 
     squared_error = (a - b) ** 2
     if weights is not None:
-        return np.sum(squared_error * weights, axis=axis) / np.sum(
+        return sumfunc(squared_error * weights, axis=axis) / sumfunc(
             weights, axis=axis
         )
     else:
@@ -231,9 +220,9 @@ def _mae(a, b, weights, axis, skipna):
     axis : int
         The axis to apply the mae along.
     weights : ndarray
-        Input array.
+        Input array of weights for a and b.
     skipna : bool
-        Whether or not to skip NaNs.
+        If True, skip NaNs when computing function.
 
     Returns
     -------
@@ -250,7 +239,7 @@ def _mae(a, b, weights, axis, skipna):
 
     absolute_error = np.absolute(a - b)
     if weights is not None:
-        return np.sum(absolute_error * weights, axis=axis) / np.sum(
+        return sumfunc(absolute_error * weights, axis=axis) / sumfunc(
             weights, axis=axis
         )
     else:

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -15,6 +15,7 @@ def _check_weights(weights):
     else:
         return weights
 
+
 def _get_numpy_funcs(skipna):
     """
     Returns nansum and nanmean if skipna is True;
@@ -124,7 +125,7 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
     scipy.stats.pearsonr
 
     """
-    r = _pearson_r(a, b, weights, axis)
+    r = _pearson_r(a, b, weights, axis, skipna)
     a = np.rollaxis(a, axis)
     df = a.shape[0] - 2
     t_squared = r ** 2 * (df / ((1.0 - r) * (1.0 + r)))

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -16,6 +16,17 @@ def _check_weights(weights):
         return weights
 
 
+def _check_weights(weights):
+    """
+    Quick check if weights are all NaN. If so,
+    return None to guide weighting scheme.
+    """
+    if np.all(np.isnan(weights)):
+        return None
+    else:
+        return weights
+
+
 def _pearson_r(a, b, weights, axis):
     """
     ndarray implementation of scipy.stats.pearsonr.

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -24,7 +24,6 @@ from xskillscore.core.np_deterministic import (
 
 AXES = ("time", "lat", "lon", ("lat", "lon"), ("time", "lat", "lon"))
 
-
 @pytest.fixture
 def a():
     dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
@@ -75,15 +74,37 @@ def weights_dask():
     ).chunk()
 
 
+
 @pytest.fixture
-def weights_ones():
-    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+def weights():
+    """
+    Weighting array by cosine of the latitude.
+    """
+    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)
     lons = np.arange(5)
-    data = np.ones((len(dates), len(lats), len(lons)))
-    return xr.DataArray(data,
-                        coords=[dates, lats, lons],
-                        dims=['time', 'lat', 'lon'])
+    cos = np.abs(np.cos(lats))
+    data = np.tile(cos, (len(dates), len(lons), 1)).reshape(
+        len(dates), len(lats), len(lons)
+    )
+    return xr.DataArray(data, coords=[dates, lats, lons], dims=["time", "lat", "lon"])
+
+
+@pytest.fixture
+def weights_dask():
+    """
+    Weighting array by cosine of the latitude.
+    """
+    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
+    lats = np.arange(4)
+    lons = np.arange(5)
+    cos = np.abs(np.cos(lats))
+    data = np.tile(cos, (len(dates), len(lons), 1)).reshape(
+        len(dates), len(lats), len(lons)
+    )
+    return xr.DataArray(
+        data, coords=[dates, lats, lons], dims=["time", "lat", "lon"]
+    ).chunk()
 
 
 @pytest.fixture

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -76,6 +76,17 @@ def weights_dask():
 
 
 @pytest.fixture
+def weights_ones():
+    dates = pd.date_range('1/1/2000', '1/3/2000', freq='D')
+    lats = np.arange(4)
+    lons = np.arange(5)
+    data = np.ones((len(dates), len(lats), len(lons)))
+    return xr.DataArray(data,
+                        coords=[dates, lats, lons],
+                        dims=['time', 'lat', 'lon'])
+
+
+@pytest.fixture
 def a_dask():
     dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -165,7 +165,7 @@ def test_pearson_r_xr(a, b, dim, weight, weights):
     _weights = _preprocess_weights(_a, dim, new_dim, _weights)
 
     axis = _a.dims.index(new_dim)
-    res = _pearson_r(_a.values, _b.values, _weights.values, axis)
+    res = _pearson_r(_a.values, _b.values, _weights.values, axis, skipna=False)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -194,7 +194,7 @@ def test_pearson_r_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
     _weights = _preprocess_weights(_a_dask, dim, new_dim, _weights)
 
     axis = _a_dask.dims.index(new_dim)
-    res = _pearson_r(_a_dask.values, _b_dask.values, _weights.values, axis)
+    res = _pearson_r(_a_dask.values, _b_dask.values, _weights.values, axis, skipna=False)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -223,7 +223,7 @@ def test_pearson_r_p_value_xr(a, b, dim, weight, weights):
     _weights = _preprocess_weights(_a, dim, new_dim, _weights)
 
     axis = _a.dims.index(new_dim)
-    res = _pearson_r_p_value(_a.values, _b.values, _weights.values, axis)
+    res = _pearson_r_p_value(_a.values, _b.values, _weights.values, axis, skipna=False)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -252,7 +252,7 @@ def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
     _weights = _preprocess_weights(_a_dask, dim, new_dim, _weights)
 
     axis = _a_dask.dims.index(new_dim)
-    res = _pearson_r_p_value(_a_dask.values, _b_dask.values, _weights.values, axis)
+    res = _pearson_r_p_value(_a_dask.values, _b_dask.values, _weights.values, axis, skipna=False)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -24,13 +24,16 @@ from xskillscore.core.np_deterministic import (
 
 AXES = ("time", "lat", "lon", ("lat", "lon"), ("time", "lat", "lon"))
 
+
 @pytest.fixture
 def a():
     dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)
     lons = np.arange(5)
     data = np.random.rand(len(dates), len(lats), len(lons))
-    return xr.DataArray(data, coords=[dates, lats, lons], dims=["time", "lat", "lon"])
+    return xr.DataArray(
+        data, coords=[dates, lats, lons], dims=["time", "lat", "lon"]
+    )
 
 
 @pytest.fixture
@@ -39,26 +42,13 @@ def b():
     lats = np.arange(4)
     lons = np.arange(5)
     data = np.random.rand(len(dates), len(lats), len(lons))
-    return xr.DataArray(data, coords=[dates, lats, lons], dims=["time", "lat", "lon"])
+    return xr.DataArray(
+        data, coords=[dates, lats, lons], dims=["time", "lat", "lon"]
+    )
 
 
 @pytest.fixture
 def weights():
-    """
-    Weighting array by cosine of the latitude.
-    """
-    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
-    lats = np.arange(4)
-    lons = np.arange(5)
-    cos = np.abs(np.cos(lats))
-    data = np.tile(cos, (len(dates), len(lons), 1)).reshape(
-        len(dates), len(lats), len(lons)
-    )
-    return xr.DataArray(data, coords=[dates, lats, lons], dims=["time", "lat", "lon"])
-
-
-@pytest.fixture
-def weights_dask():
     """
     Weighting array by cosine of the latitude.
     """
@@ -71,23 +61,7 @@ def weights_dask():
     )
     return xr.DataArray(
         data, coords=[dates, lats, lons], dims=["time", "lat", "lon"]
-    ).chunk()
-
-
-
-@pytest.fixture
-def weights():
-    """
-    Weighting array by cosine of the latitude.
-    """
-    dates = pd.date_range("1/1/2000", "1/3/2000", freq="D")
-    lats = np.arange(4)
-    lons = np.arange(5)
-    cos = np.abs(np.cos(lats))
-    data = np.tile(cos, (len(dates), len(lons), 1)).reshape(
-        len(dates), len(lats), len(lons)
     )
-    return xr.DataArray(data, coords=[dates, lats, lons], dims=["time", "lat", "lon"])
 
 
 @pytest.fixture
@@ -145,7 +119,8 @@ def adjust_weights(dim, weight, weights):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_pearson_r_xr(a, b, dim, weight, weights):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     _weights = adjust_weights(dim, weight, weights)
 
     actual = pearson_r(a, b, dim, weights=_weights)
@@ -174,7 +149,8 @@ def test_pearson_r_xr(a, b, dim, weight, weights):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_pearson_r_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     _weights = adjust_weights(dim, weight, weights_dask)
 
     actual = pearson_r(a_dask, b_dask, dim, weights=_weights)
@@ -194,7 +170,9 @@ def test_pearson_r_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
     _weights = _preprocess_weights(_a_dask, dim, new_dim, _weights)
 
     axis = _a_dask.dims.index(new_dim)
-    res = _pearson_r(_a_dask.values, _b_dask.values, _weights.values, axis, skipna=False)
+    res = _pearson_r(
+        _a_dask.values, _b_dask.values, _weights.values, axis, skipna=False
+    )
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -203,7 +181,8 @@ def test_pearson_r_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_pearson_r_p_value_xr(a, b, dim, weight, weights):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     _weights = adjust_weights(dim, weight, weights)
 
     actual = pearson_r_p_value(a, b, dim, weights=_weights)
@@ -223,7 +202,9 @@ def test_pearson_r_p_value_xr(a, b, dim, weight, weights):
     _weights = _preprocess_weights(_a, dim, new_dim, _weights)
 
     axis = _a.dims.index(new_dim)
-    res = _pearson_r_p_value(_a.values, _b.values, _weights.values, axis, skipna=False)
+    res = _pearson_r_p_value(
+        _a.values, _b.values, _weights.values, axis, skipna=False
+    )
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -232,7 +213,8 @@ def test_pearson_r_p_value_xr(a, b, dim, weight, weights):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     _weights = adjust_weights(dim, weight, weights_dask)
 
     actual = pearson_r_p_value(a_dask, b_dask, dim, weights=_weights)
@@ -252,7 +234,9 @@ def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
     _weights = _preprocess_weights(_a_dask, dim, new_dim, _weights)
 
     axis = _a_dask.dims.index(new_dim)
-    res = _pearson_r_p_value(_a_dask.values, _b_dask.values, _weights.values, axis, skipna=False)
+    res = _pearson_r_p_value(
+        _a_dask.values, _b_dask.values, _weights.values, axis, skipna=False
+    )
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -261,7 +245,8 @@ def test_pearson_r_p_value_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_rmse_xr(a, b, dim, weight, weights):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     weights = adjust_weights(dim, weight, weights)
 
     actual = rmse(a, b, dim, weights=weights)
@@ -272,7 +257,7 @@ def test_rmse_xr(a, b, dim, weight, weights):
     _b = b
     _weights = _preprocess_weights(_a, dim, dim, weights)
     axis = tuple(a.dims.index(d) for d in dim)
-    res = _rmse(_a.values, _b.values, _weights.values, axis)
+    res = _rmse(_a.values, _b.values, _weights.values, axis, skipna=False)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -281,7 +266,8 @@ def test_rmse_xr(a, b, dim, weight, weights):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_rmse_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     _weights = adjust_weights(dim, weight, weights_dask)
 
     actual = rmse(a_dask, b_dask, dim, weights=_weights)
@@ -292,7 +278,9 @@ def test_rmse_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
     _b_dask = b_dask
     _weights = _preprocess_weights(_a_dask, dim, dim, _weights)
     axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _rmse(_a_dask.values, _b_dask.values, _weights.values, axis)
+    res = _rmse(
+        _a_dask.values, _b_dask.values, _weights.values, axis, skipna=False
+    )
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -301,7 +289,8 @@ def test_rmse_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_mse_xr(a, b, dim, weight, weights):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     weights = adjust_weights(dim, weight, weights)
 
     actual = mse(a, b, dim, weights=weights)
@@ -312,7 +301,7 @@ def test_mse_xr(a, b, dim, weight, weights):
     _b = b
     _weights = _preprocess_weights(_a, dim, dim, weights)
     axis = tuple(a.dims.index(d) for d in dim)
-    res = _mse(_a.values, _b.values, _weights.values, axis)
+    res = _mse(_a.values, _b.values, _weights.values, axis, skipna=False)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -321,7 +310,8 @@ def test_mse_xr(a, b, dim, weight, weights):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_mse_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     _weights = adjust_weights(dim, weight, weights_dask)
 
     actual = mse(a_dask, b_dask, dim, weights=_weights)
@@ -332,7 +322,9 @@ def test_mse_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
     _b_dask = b_dask
     _weights = _preprocess_weights(_a_dask, dim, dim, _weights)
     axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _mse(_a_dask.values, _b_dask.values, _weights.values, axis)
+    res = _mse(
+        _a_dask.values, _b_dask.values, _weights.values, axis, skipna=False
+    )
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -341,7 +333,8 @@ def test_mse_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_mae_xr(a, b, dim, weight, weights):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     weights = adjust_weights(dim, weight, weights)
 
     actual = mae(a, b, dim, weights=weights)
@@ -352,7 +345,7 @@ def test_mae_xr(a, b, dim, weight, weights):
     _b = b
     _weights = _preprocess_weights(_a, dim, dim, weights)
     axis = tuple(a.dims.index(d) for d in dim)
-    res = _mae(_a.values, _b.values, _weights.values, axis)
+    res = _mae(_a.values, _b.values, _weights.values, axis, skipna=False)
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)
@@ -361,7 +354,8 @@ def test_mae_xr(a, b, dim, weight, weights):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight", [True, False])
 def test_mae_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
-    # Generates subsetted weights to pass in as arg to main function and for the numpy testing.
+    # Generates subsetted weights to pass in as arg to main function and for
+    # the numpy testing.
     _weights = adjust_weights(dim, weight, weights_dask)
     actual = mae(a_dask, b_dask, dim, weights=_weights)
     assert actual.chunks is not None
@@ -371,7 +365,9 @@ def test_mae_xr_dask(a_dask, b_dask, dim, weight, weights_dask):
     _b_dask = b_dask
     _weights = _preprocess_weights(_a_dask, dim, dim, _weights)
     axis = tuple(a_dask.dims.index(d) for d in dim)
-    res = _mae(_a_dask.values, _b_dask.values, _weights.values, axis)
+    res = _mae(
+        _a_dask.values, _b_dask.values, _weights.values, axis, skipna=False
+    )
     expected = actual.copy()
     expected.values = res
     assert_allclose(actual, expected)

--- a/xskillscore/tests/test_mask_skipna.py
+++ b/xskillscore/tests/test_mask_skipna.py
@@ -1,0 +1,84 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from xskillscore.core.deterministic import (
+    mae,
+    mse,
+    pearson_r,
+    pearson_r_p_value,
+    rmse,
+)
+
+
+# Should only have masking issues when pulling in masked
+# grid cells over space.
+AXES = (("lat", "lon"), ("time", "lat", "lon"))
+
+
+@pytest.fixture
+def a_masked():
+    time = pd.date_range("1/1/2000", "1/3/2000", freq="D")
+    lats = np.arange(4)
+    lons = np.arange(5)
+    data = np.random.rand(len(time), len(lats), len(lons))
+    da = xr.DataArray(
+        data, coords=[time, lats, lons], dims=["time", "lat", "lon"]
+    )
+    # Mask an arbitrary region with NaNs (like a block of land).
+    return da.where(da.lon > 1)
+
+
+@pytest.fixture
+def b_masked():
+    time = pd.date_range("1/1/2000", "1/3/2000", freq="D")
+    lats = np.arange(4)
+    lons = np.arange(5)
+    data = np.random.rand(len(time), len(lats), len(lons))
+    da = xr.DataArray(
+        data, coords=[time, lats, lons], dims=["time", "lat", "lon"]
+    )
+    # Mask an arbitrary region with NaNs (like a block of land).
+    return da.where(da.lon > 1)
+
+
+@pytest.mark.parametrize("dim", AXES)
+def test_pearson_r_masked(a_masked, b_masked, dim):
+    res_skipna = pearson_r(a_masked, b_masked, dim, skipna=True)
+    res_no_skipna = pearson_r(a_masked, b_masked, dim, skipna=False)
+    assert np.isnan(res_no_skipna).all()
+    assert not np.isnan(res_skipna).any()
+
+
+@pytest.mark.parametrize("dim", AXES)
+def test_pearson_r_p_value_masked(a_masked, b_masked, dim):
+    res_skipna = pearson_r_p_value(a_masked, b_masked, dim, skipna=True)
+    res_no_skipna = pearson_r_p_value(a_masked, b_masked, dim, skipna=False)
+    # p-value defaults to exactly 1.0 instead of NaNs.
+    assert (res_no_skipna == 1.0).all()
+    assert not np.isnan(res_skipna).any()
+
+
+@pytest.mark.parametrize("dim", AXES)
+def test_rmse_masked(a_masked, b_masked, dim):
+    res_skipna = rmse(a_masked, b_masked, dim, skipna=True)
+    res_no_skipna = rmse(a_masked, b_masked, dim, skipna=False)
+    assert np.isnan(res_no_skipna).all()
+    assert not np.isnan(res_skipna).any()
+
+
+@pytest.mark.parametrize("dim", AXES)
+def test_mse_masked(a_masked, b_masked, dim):
+    res_skipna = mse(a_masked, b_masked, dim, skipna=True)
+    res_no_skipna = mse(a_masked, b_masked, dim, skipna=False)
+    assert np.isnan(res_no_skipna).all()
+    assert not np.isnan(res_skipna).any()
+
+
+@pytest.mark.parametrize("dim", AXES)
+def test_mae_masked(a_masked, b_masked, dim):
+    res_skipna = mae(a_masked, b_masked, dim, skipna=True)
+    res_no_skipna = mae(a_masked, b_masked, dim, skipna=False)
+    assert np.isnan(res_no_skipna).all()
+    assert not np.isnan(res_skipna).any()

--- a/xskillscore/tests/test_mask_skipna.py
+++ b/xskillscore/tests/test_mask_skipna.py
@@ -14,11 +14,11 @@ from xskillscore.core.deterministic import (
 
 # Should only have masking issues when pulling in masked
 # grid cells over space.
-AXES = (("lat", "lon"), ("time", "lat", "lon"))
+AXES = [["time"], ["lat"], ["lon"], ("lat", "lon"), ("time", "lat", "lon")]
 
 
 @pytest.fixture
-def a_masked():
+def a():
     time = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)
     lons = np.arange(5)
@@ -26,12 +26,11 @@ def a_masked():
     da = xr.DataArray(
         data, coords=[time, lats, lons], dims=["time", "lat", "lon"]
     )
-    # Mask an arbitrary region with NaNs (like a block of land).
-    return da.where(da.lon > 1)
+    return da
 
 
 @pytest.fixture
-def b_masked():
+def b():
     time = pd.date_range("1/1/2000", "1/3/2000", freq="D")
     lats = np.arange(4)
     lons = np.arange(5)
@@ -39,12 +38,22 @@ def b_masked():
     da = xr.DataArray(
         data, coords=[time, lats, lons], dims=["time", "lat", "lon"]
     )
+    return da
+
+
+def mask_data(da, dim):
+    """
+    Masks sample data arbitrarily over specified dim.
+    """
     # Mask an arbitrary region with NaNs (like a block of land).
-    return da.where(da.lon > 1)
+    return da.where(da[dim] > da[dim].isel({dim: 0}))
 
 
 @pytest.mark.parametrize("dim", AXES)
-def test_pearson_r_masked(a_masked, b_masked, dim):
+def test_pearson_r_masked(a, b, dim):
+    a_masked = mask_data(a, dim[0])
+    b_masked = mask_data(b, dim[0])
+
     res_skipna = pearson_r(a_masked, b_masked, dim, skipna=True)
     res_no_skipna = pearson_r(a_masked, b_masked, dim, skipna=False)
     assert np.isnan(res_no_skipna).all()
@@ -52,7 +61,10 @@ def test_pearson_r_masked(a_masked, b_masked, dim):
 
 
 @pytest.mark.parametrize("dim", AXES)
-def test_pearson_r_p_value_masked(a_masked, b_masked, dim):
+def test_pearson_r_p_value_masked(a, b, dim):
+    a_masked = mask_data(a, dim[0])
+    b_masked = mask_data(b, dim[0])
+
     res_skipna = pearson_r_p_value(a_masked, b_masked, dim, skipna=True)
     res_no_skipna = pearson_r_p_value(a_masked, b_masked, dim, skipna=False)
     # p-value defaults to exactly 1.0 instead of NaNs.
@@ -61,7 +73,10 @@ def test_pearson_r_p_value_masked(a_masked, b_masked, dim):
 
 
 @pytest.mark.parametrize("dim", AXES)
-def test_rmse_masked(a_masked, b_masked, dim):
+def test_rmse_masked(a, b, dim):
+    a_masked = mask_data(a, dim[0])
+    b_masked = mask_data(b, dim[0])
+
     res_skipna = rmse(a_masked, b_masked, dim, skipna=True)
     res_no_skipna = rmse(a_masked, b_masked, dim, skipna=False)
     assert np.isnan(res_no_skipna).all()
@@ -69,7 +84,10 @@ def test_rmse_masked(a_masked, b_masked, dim):
 
 
 @pytest.mark.parametrize("dim", AXES)
-def test_mse_masked(a_masked, b_masked, dim):
+def test_mse_masked(a, b, dim):
+    a_masked = mask_data(a, dim[0])
+    b_masked = mask_data(b, dim[0])
+
     res_skipna = mse(a_masked, b_masked, dim, skipna=True)
     res_no_skipna = mse(a_masked, b_masked, dim, skipna=False)
     assert np.isnan(res_no_skipna).all()
@@ -77,7 +95,10 @@ def test_mse_masked(a_masked, b_masked, dim):
 
 
 @pytest.mark.parametrize("dim", AXES)
-def test_mae_masked(a_masked, b_masked, dim):
+def test_mae_masked(a, b, dim):
+    a_masked = mask_data(a, dim[0])
+    b_masked = mask_data(b, dim[0])
+
     res_skipna = mae(a_masked, b_masked, dim, skipna=True)
     res_no_skipna = mae(a_masked, b_masked, dim, skipna=False)
     assert np.isnan(res_no_skipna).all()


### PR DESCRIPTION
Addresses #30, #34, #35

This adds a `skipna=bool` option on all high-level deterministic functions. This is necessary in cases where the user enters in an `a` and `b` with say, a spatial mask applied (or with continents NaNed out even). Currently, the underlying numpy commands return NaNs since they encounter NaNs on the spatial grid while summing and taking means.

Here I just call a quick helper function which returns a variable function generically named, so it doesn't muddy up the code too much.

Testing just uses `['lat', 'lon']` and `['lat', 'lon', 'time']` since the NaN masking issue is very clear over these axes. Also `test_deterministic` assesses accuracy in the high level functions, weighting, etc. so I didn't want any redundancies here.