### PR TITLE
Fix all nans in pearson_r pval

### DIFF
--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -142,7 +142,7 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
     res = special.betainc(_a, _b, _x)
     # reset masked values to nan
     nan_locs = np.where(np.isnan(r))
-    if len(nan_locs) > 0:
+    if len(nan_locs[0].ravel()) > 0:
         res[nan_locs] = np.nan
     return res
 

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -141,8 +141,7 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
     _b = 0.5
     res = special.betainc(_a, _b, _x)
     # reset masked values to nan
-    all_nan = np.isnan(a.mean(axis=0) * b.mean(axis=0))
-    res = np.where(all_nan, np.nan, res)
+    res[np.where(np.isnan(r))] = np.nan
     return res
 
 

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -129,24 +129,28 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
 
     """
     r = _pearson_r(a, b, weights, axis, skipna)
-    a = np.rollaxis(a, axis)
-    b = np.rollaxis(b, axis)
-    dof = np.apply_over_axes(np.sum, np.isnan(a * b), 0).squeeze() - 2
-    dof = np.where(dof > 1.0, dof, a.shape[0] - 2)
-    t_squared = r ** 2 * (dof / ((1.0 - r) * (1.0 + r)))
-    _x = dof / (dof + t_squared)
-    _x = np.asarray(_x)
-    _x = np.where(_x < 1.0, _x, 1.0)
-    _a = 0.5 * dof
-    _b = 0.5
-    res = special.betainc(_a, _b, _x)
-    # reset masked values to nan
-    nan_locs = np.where(np.isnan(r))
-    if len(nan_locs[0].ravel()) > 0:
-        res[nan_locs] = np.nan
-    return res
+    if np.isnan(r).all():
+        return r
+    else:
+        # no nans or some nans
+        a = np.rollaxis(a, axis)
+        b = np.rollaxis(b, axis)
+        dof = np.apply_over_axes(np.sum, np.isnan(a * b), 0).squeeze() - 2
+        dof = np.where(dof > 1.0, dof, a.shape[0] - 2)
+        t_squared = r ** 2 * (dof / ((1.0 - r) * (1.0 + r)))
+        _x = dof / (dof + t_squared)
+        _x = np.asarray(_x)
+        _x = np.where(_x < 1.0, _x, 1.0)
+        _a = 0.5 * dof
+        _b = 0.5
+        res = special.betainc(_a, _b, _x)
+        # reset masked values to nan
+        nan_locs = np.where(np.isnan(r))
+        if len(nan_locs[0]) > 0:
+            res[nan_locs] = np.nan
+        return res
 
-
+    
 def _spearman_r(a, b, weights, axis, skipna):
     """
     ndarray implementation of scipy.stats.spearmanr.

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -141,7 +141,9 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
     _b = 0.5
     res = special.betainc(_a, _b, _x)
     # reset masked values to nan
-    res[np.where(np.isnan(r))] = np.nan
+    nan_locs = np.where(np.isnan(r))
+    if len(nan_locs) > 0:
+        res[nan_locs] = np.nan
     return res
 
 

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -260,5 +260,5 @@ def test_percentage_metric_in_interval_0_1(a, b, dim, metric):
 
 
 def test_pearson_r_p_value_skipna(a, b_nan):
-    res = pearson_r_p_value(a, b_nan, ['lat', 'lon'])
+    res = pearson_r_p_value(a, b_nan, ['lat', 'lon'], skipna=True)
     assert not np.isnan(res).all()

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -260,5 +260,6 @@ def test_percentage_metric_in_interval_0_1(a, b, dim, metric):
 
 
 def test_pearson_r_p_value_skipna(a, b_nan):
+    """Test whether NaNs sprinkled in array will NOT yield all NaNs."""
     res = pearson_r_p_value(a, b_nan, ['lat', 'lon'], skipna=True)
     assert not np.isnan(res).all()

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -67,6 +67,11 @@ def b(a):
 
 
 @pytest.fixture
+def b_nan(b):
+    return b.where(b < 0.5)
+
+
+@pytest.fixture
 def weights(a):
     """
     Weighting array by cosine of the latitude.
@@ -252,3 +257,8 @@ def test_percentage_metric_in_interval_0_1(a, b, dim, metric):
     assert not (res < 0).any()
     assert not (res > 1).any()
     assert not res.isnull().any()
+
+
+def test_pearson_r_p_value_skipna(a, b_nan):
+    res = pearson_r_p_value(a, b_nan, ['lat', 'lon'])
+    assert not np.isnan(res).all()

--- a/xskillscore/tests/test_mask_skipna.py
+++ b/xskillscore/tests/test_mask_skipna.py
@@ -9,7 +9,7 @@ from xskillscore.core.deterministic import (mad, mae, mape, mse, pearson_r,
 
 # Should only have masking issues when pulling in masked
 # grid cells over space.
-AXES = [['time'], ['lat'], ['lon'], ('lat', 'lon'), ('time', 'lat', 'lon')]
+AXES = ('time', 'lat', 'lon', ('lat', 'lon'), ('time', 'lat', 'lon'))
 
 distance_metrics = [mae, mse, mad, mape, smape, rmse]
 correlation_metrics = [

--- a/xskillscore/tests/test_np_deterministic.py
+++ b/xskillscore/tests/test_np_deterministic.py
@@ -135,8 +135,6 @@ def test_spearman_r_nd(a, b):
 def test_spearman_r_p_value_nd(a, b):
     nan_policy = 'propagate'  # default
     axis = 0
-    print(a)
-    print(b)
     expected = np.squeeze(a[0, :, :]).copy()
     for i in range(np.shape(a)[1]):
         for j in range(np.shape(a)[2]):


### PR DESCRIPTION
Since pearson_r works as expected, use the location of NaNs from pearson_r. Also less computation since it doesn't have to perform the mean.

https://github.com/raybellwaves/xskillscore/issues/45