### PR TITLE
Fix `skipna` bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,25 @@
+=================
+Changelog History
+=================
+
+xskillscore v0.0.10 (2019-12-##)
+================================
+
+Deprecations
+------------
+- ``mad`` no longer works and is replaced by ``median_absolute_deviation``. `Riley X. Brady`_
+
+Features
+--------
+
+Bug Fixes
+---------
+- ``skipna`` for ``pearson_r`` and ``spearman_r`` and their p-values now reports accurate results when there are pairwise nans (i.e., nans that occur in different indices in ``a`` and ``b``) `Riley X. Brady`_
+
+Testing
+-------
+- Test that results from grid cells in a gridded product match the same value if their time series were input directly into functions. `Riley X. Brady`_
+- Test that metric results from ``xskillscore`` are the same value as an external package (e.g. ``numpy``, ``scipy``, ``sklearn``). `Riley X. Brady`_
+- Test that ``skipna=True`` works properly with pairwise nans. `Riley X. Brady`_
+
+.. _`Riley X. Brady`: https://github.com/bradyrx

--- a/xskillscore/__init__.py
+++ b/xskillscore/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from .core.accessor import XSkillScoreAccessor
 from .core.deterministic import (
-    mad,
+    median_absolute_error,
     mae,
     mape,
     mse,

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -1,7 +1,7 @@
 import xarray as xr
 
 from .np_deterministic import (
-    _mad,
+    _median_absolute_error,
     _mae,
     _mape,
     _mse,
@@ -19,7 +19,7 @@ __all__ = [
     "rmse",
     "mse",
     "mae",
-    "mad",
+    "median_absolute_error",
     "smape",
     "mape",
     "spearman_r",
@@ -454,9 +454,9 @@ def mae(a, b, dim, weights=None, skipna=False):
     )
 
 
-def mad(a, b, dim, skipna=False):
+def median_absolute_error(a, b, dim, skipna=False):
     """
-    Median Absolute Deviation.
+    Median Absolute Error.
 
     Parameters
     ----------
@@ -465,30 +465,26 @@ def mad(a, b, dim, skipna=False):
     b : xarray.Dataset or xarray.DataArray
         Labeled array(s) over which to apply the function.
     dim : str, list
-        The dimension(s) to apply the mae along.
+        The dimension(s) to apply the median absolute error along.
     skipna : bool
         If True, skip NaNs when computing function.
 
     Returns
     -------
     xarray.Dataset or xarray.DataArray
-        Median Absolute Deviation.
+        Median Absolute Error.
 
     See Also
     --------
     sklearn.metrics.median_absolute_error
     xarray.apply_ufunc
-    xskillscore.core.np_deterministic._mad
-
-    Reference
-    ---------
-    https://en.wikipedia.org/wiki/Median_absolute_deviation
+    xskillscore.core.np_deterministic._median_absolute_error
 
     """
     dim, axis = _preprocess_dims(dim)
 
     return xr.apply_ufunc(
-        _mad,
+        _median_absolute_error,
         a,
         b,
         input_core_dims=[dim, dim],

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -246,8 +246,7 @@ def _spearman_r_p_value(a, b, weights, axis, skipna):
     rs = _spearman_r(a, b, weights, axis, skipna)
     a = np.rollaxis(a, axis)
     b = np.rollaxis(b, axis)
-    # can just count non-nans on `a` since we matched
-    # nans above.
+    # count non-nans
     dof = np.count_nonzero(~np.isnan(a), axis=0) - 2
     t = rs * np.sqrt((dof / ((rs + 1.0) * (1.0 - rs))).clip(0))
     p = 2 * distributions.t.sf(np.abs(t), dof)

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -159,8 +159,9 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
         # no nans or some nans
         a = np.rollaxis(a, axis)
         b = np.rollaxis(b, axis)
-        dof = np.apply_over_axes(np.sum, np.isnan(a * b), 0).squeeze() - 2
-        dof = np.where(dof > 1.0, dof, a.shape[0] - 2)
+        # can just count non-nans on `a` since we matched
+        # nans above.
+        dof = np.count_nonzero(~np.isnan(a), axis=0) - 2
         t_squared = r ** 2 * (dof / ((1.0 - r) * (1.0 + r)))
         _x = dof / (dof + t_squared)
         _x = np.asarray(_x)
@@ -246,8 +247,9 @@ def _spearman_r_p_value(a, b, weights, axis, skipna):
     rs = _spearman_r(a, b, weights, axis, skipna)
     a = np.rollaxis(a, axis)
     b = np.rollaxis(b, axis)
-    dof = np.apply_over_axes(np.sum, np.isnan(a * b), 0).squeeze() - 2
-    dof = np.where(dof > 1.0, dof, a.shape[0] - 2)
+    # can just count non-nans on `a` since we matched
+    # nans above.
+    dof = np.count_nonzero(~np.isnan(a), axis=0) - 2
     t = rs * np.sqrt((dof / ((rs + 1.0) * (1.0 - rs))).clip(0))
     p = 2 * distributions.t.sf(np.abs(t), dof)
     return p

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -9,7 +9,7 @@ __all__ = [
     "_rmse",
     "_mse",
     "_mae",
-    "_mad",
+    "_median_absolute_error",
     "_smape",
     "_mape",
     "_spearman_r",
@@ -378,9 +378,9 @@ def _mae(a, b, weights, axis, skipna):
         return meanfunc(absolute_error, axis=axis)
 
 
-def _mad(a, b, axis, skipna):
+def _median_absolute_error(a, b, axis, skipna):
     """
-    Median Absolute Deviation.
+    Median Absolute Error.
 
     Parameters
     ----------
@@ -389,18 +389,18 @@ def _mad(a, b, axis, skipna):
     b : ndarray
         Input array.
     axis : int
-        The axis to apply the mad along.
+        The axis to apply the median absolute error along.
     skipna : bool
         If True, skip NaNs when computing function.
 
     Returns
     -------
     res : ndarray
-        Median Absolute Deviation.
+        Median Absolute Error.
 
     See Also
     --------
-    scipy.stats.median_absolute_deviation
+    sklearn.metrics.median_absolute_error
 
     """
     medianfunc = np.nanmedian if skipna else np.median

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -246,7 +246,7 @@ def _spearman_r_p_value(a, b, weights, axis, skipna):
     rs = _spearman_r(a, b, weights, axis, skipna)
     a = np.rollaxis(a, axis)
     b = np.rollaxis(b, axis)
-    dof = np.apply_over_axes(np.sum, ~np.isnan(a * b), 0).squeeze() - 2
+    dof = np.apply_over_axes(np.sum, np.isnan(a * b), 0).squeeze() - 2
     dof = np.where(dof > 1.0, dof, a.shape[0] - 2)
     t = rs * np.sqrt((dof / ((rs + 1.0) * (1.0 - rs))).clip(0))
     p = 2 * distributions.t.sf(np.abs(t), dof)

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -159,8 +159,7 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
         # no nans or some nans
         a = np.rollaxis(a, axis)
         b = np.rollaxis(b, axis)
-        # can just count non-nans on `a` since we matched
-        # nans above.
+        # count non-nans
         dof = np.count_nonzero(~np.isnan(a), axis=0) - 2
         t_squared = r ** 2 * (dof / ((1.0 - r) * (1.0 + r)))
         _x = dof / (dof + t_squared)

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -7,7 +7,7 @@ from xarray.tests import assert_allclose
 from xskillscore.core.deterministic import (
     _preprocess_dims,
     _preprocess_weights,
-    mad,
+    median_absolute_error,
     mae,
     mape,
     mse,
@@ -19,7 +19,7 @@ from xskillscore.core.deterministic import (
     spearman_r_p_value,
 )
 from xskillscore.core.np_deterministic import (
-    _mad,
+    _median_absolute_error,
     _mae,
     _mape,
     _mse,
@@ -41,7 +41,7 @@ distance_metrics = [
     (mse, _mse),
     (rmse, _rmse),
     (mae, _mae),
-    (mad, _mad),
+    (median_absolute_error, _median_absolute_error),
     (mape, _mape),
     (smape, _smape),
 ]
@@ -163,8 +163,8 @@ def test_distance_metrics_xr(a, b, dim, weight_bool, weights, metrics):
     # Generates subsetted weights to pass in as arg to main function and for
     # the numpy testing.
     weights = adjust_weights(dim, weight_bool, weights)
-    # mad has no weights argument
-    if metric is mad:
+    # median absolute error has no weights argument
+    if metric is median_absolute_error:
         actual = metric(a, b, dim)
     else:
         actual = metric(a, b, dim, weights=weights)
@@ -175,7 +175,7 @@ def test_distance_metrics_xr(a, b, dim, weight_bool, weights, metrics):
     _b = b
     _weights = _preprocess_weights(_a, dim, dim, weights)
     axis = tuple(a.dims.index(d) for d in dim)
-    if metric is mad:
+    if metric is median_absolute_error:
         res = _metric(_a.values, _b.values, axis, skipna=False)
     else:
         res = _metric(_a.values, _b.values, _weights.values, axis, skipna=False)
@@ -231,13 +231,13 @@ def test_distance_metrics_xr_dask(
     _weights = adjust_weights(dim, weight_bool, weights)
     if _weights is not None:
         _weights = _weights.load()
-    if metric is mad:
+    if metric is median_absolute_error:
         actual = metric(a, b, dim)
     else:
         actual = metric(a, b, dim, weights=_weights)
     # check that chunks for chunk inputs
     assert actual.chunks is not None
-    if metric is mad:
+    if metric is median_absolute_error:
         expected = metric(a.load(), b.load(), dim)
     else:
         expected = metric(a.load(), b.load(), dim, weights=_weights)

--- a/xskillscore/tests/test_gridded_metrics.py
+++ b/xskillscore/tests/test_gridded_metrics.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from xskillscore.core.deterministic import (
+    median_absolute_error,
+    mae,
+    mape,
+    mse,
+    pearson_r,
+    pearson_r_p_value,
+    rmse,
+    smape,
+    spearman_r,
+    spearman_r_p_value,
+)
+
+METRICS = [
+    mae,
+    mse,
+    median_absolute_error,
+    mape,
+    smape,
+    rmse,
+    pearson_r,
+    pearson_r_p_value,
+    spearman_r,
+    spearman_r_p_value,
+]
+
+
+@pytest.fixture
+def gridded_a():
+    time = pd.date_range("1/1/2000", "1/5/2000", freq="D")
+    lats = np.arange(3)
+    lons = np.arange(3)
+    data = np.random.rand(len(time), len(lats), len(lons))
+    da = xr.DataArray(data, coords=[time, lats, lons], dims=["time", "lat", "lon"])
+    return da
+
+
+@pytest.fixture
+def gridded_b(gridded_a):
+    b = gridded_a.copy()
+    b.values = np.random.rand(
+        gridded_a.shape[0], gridded_a.shape[1], gridded_a.shape[2]
+    )
+    return b
+
+
+def mask_data(da):
+    """
+    Masks sample data arbitrarily like a block of land.
+    """
+    da.data[:, 1:3, 1:3] = np.nan
+    da.data[0:2, 0, 0] = np.nan
+    return da
+
+
+@pytest.mark.parametrize("metric", METRICS)
+def test_single_grid_cell_matches_individual_time_series(gridded_a, gridded_b, metric):
+    """Test that a single grid cell result from a gridded dataset matches the
+    result for just passing through the individual time series"""
+    for x in range(gridded_a["lon"].size):
+        for y in range(gridded_a["lat"].size):
+            ts_a = gridded_a.isel(lat=y, lon=x)
+            ts_b = gridded_b.isel(lat=y, lon=x)
+            gridded_res = metric(gridded_a, gridded_b, "time").isel(lat=y, lon=x)
+            ts_res = metric(ts_a, ts_b, "time")
+            assert np.allclose(gridded_res, ts_res)
+
+
+@pytest.mark.parametrize("metric", METRICS)
+def test_single_grid_cell_matches_individual_time_series_nans(
+    gridded_a, gridded_b, metric
+):
+    """Test that a single grid cell result from a gridded dataset with nans matches the
+    result for just passing through the individual time series"""
+    gridded_a_masked = mask_data(gridded_a)
+    gridded_b_masked = mask_data(gridded_b)
+    for x in range(gridded_a_masked["lon"].size):
+        for y in range(gridded_a_masked["lat"].size):
+            ts_a_masked = gridded_a_masked.isel(lat=y, lon=x)
+            ts_b_masked = gridded_b_masked.isel(lat=y, lon=x)
+            gridded_res = metric(
+                gridded_a_masked, gridded_b_masked, "time", skipna=True
+            ).isel(lat=y, lon=x)
+            ts_res = metric(ts_a_masked, ts_b_masked, "time", skipna=True)
+            assert np.allclose(gridded_res, ts_res, equal_nan=True)

--- a/xskillscore/tests/test_mask_skipna.py
+++ b/xskillscore/tests/test_mask_skipna.py
@@ -4,7 +4,7 @@ import pytest
 import xarray as xr
 
 from xskillscore.core.deterministic import (
-    mad,
+    median_absolute_error,
     mae,
     mape,
     mse,
@@ -20,7 +20,7 @@ from xskillscore.core.deterministic import (
 # grid cells over space.
 AXES = ("time", "lat", "lon", ("lat", "lon"), ("time", "lat", "lon"))
 
-distance_metrics = [mae, mse, mad, mape, smape, rmse]
+distance_metrics = [mae, mse, median_absolute_error, mape, smape, rmse]
 correlation_metrics = [
     pearson_r,
     pearson_r_p_value,

--- a/xskillscore/tests/test_metric_results_accurate.py
+++ b/xskillscore/tests/test_metric_results_accurate.py
@@ -2,12 +2,16 @@ import numpy as np
 import pandas as pd
 import pytest
 from scipy.stats import pearsonr, spearmanr
-from sklearn.metrics import mean_squared_error, mean_absolute_error
+from sklearn.metrics import (
+    mean_squared_error,
+    mean_absolute_error,
+)
+from sklearn.metrics import median_absolute_error as sklearn_med_abs
 import xarray as xr
 
 
 from xskillscore.core.deterministic import (
-    mad,
+    median_absolute_error,
     mae,
     mape,
     mse,
@@ -18,19 +22,6 @@ from xskillscore.core.deterministic import (
     spearman_r,
     spearman_r_p_value,
 )
-
-METRICS = [
-    pearson_r,
-    pearson_r_p_value,
-    spearman_r,
-    spearman_r_p_value,
-    mae,
-    mse,
-    mad,
-    mape,
-    smape,
-    rmse,
-]
 
 
 @pytest.fixture
@@ -86,6 +77,13 @@ def test_mae_same_as_sklearn(a, b):
     xs_mse = mae(a, b, "time")
     sklearn_mse = mean_absolute_error(a, b)
     assert np.allclose(xs_mse, sklearn_mse)
+
+
+def test_median_absolute_error_same_as_sklearn(a, b):
+    """Tests that median absolute error is same as computed from sklearn."""
+    xs_median_absolute_error = median_absolute_error(a, b, "time")
+    sklearn_median_absolute_error = sklearn_med_abs(a, b)
+    assert np.allclose(xs_median_absolute_error, sklearn_median_absolute_error)
 
 
 def test_mape_same_as_numpy(a, b):

--- a/xskillscore/tests/test_metric_results_accurate.py
+++ b/xskillscore/tests/test_metric_results_accurate.py
@@ -93,3 +93,11 @@ def test_mape_same_as_numpy(a, b):
     xs_mape = mape(a, b, "time")
     np_mape = np.mean(np.abs((a - b) / a))
     assert np.allclose(xs_mape, np_mape)
+
+
+def test_smape_same_as_numpy(a, b):
+    """Tests that symmetric mean absolute percent error is same as computed
+    from numpy."""
+    xs_smape = smape(a, b, "time")
+    np_smape = 1 / len(a) * np.sum(np.abs(b - a) / (np.abs(a) + np.abs(b)))
+    assert np.allclose(xs_smape, np_smape)

--- a/xskillscore/tests/test_metric_results_accurate.py
+++ b/xskillscore/tests/test_metric_results_accurate.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.stats import pearsonr, spearmanr
+from sklearn.metrics import mean_squared_error, mean_absolute_error
+import xarray as xr
+
+
+from xskillscore.core.deterministic import (
+    mad,
+    mae,
+    mape,
+    mse,
+    pearson_r,
+    pearson_r_p_value,
+    rmse,
+    smape,
+    spearman_r,
+    spearman_r_p_value,
+)
+
+METRICS = [
+    pearson_r,
+    pearson_r_p_value,
+    spearman_r,
+    spearman_r_p_value,
+    mae,
+    mse,
+    mad,
+    mape,
+    smape,
+    rmse,
+]
+
+
+@pytest.fixture
+def a():
+    time = pd.date_range("1/1/2000", "1/5/2000", freq="D")
+    da = xr.DataArray(np.random.rand(len(time)), dims=["time"], coords=[time])
+    return da
+
+
+@pytest.fixture
+def b():
+    time = pd.date_range("1/1/2000", "1/5/2000", freq="D")
+    da = xr.DataArray(np.random.rand(len(time)), dims=["time"], coords=[time])
+    return da
+
+
+def test_pearsonr_same_as_scipy(a, b):
+    """Tests that pearson r correlation and pvalue is same as computed from
+    scipy."""
+    xs_corr = pearson_r(a, b, "time")
+    xs_p = pearson_r_p_value(a, b, "time")
+    scipy_corr, scipy_p = pearsonr(a, b)
+    assert np.allclose(xs_corr, scipy_corr)
+    assert np.allclose(xs_p, scipy_p)
+
+
+def test_spearmanr_same_as_scipy(a, b):
+    """Tests that spearman r correlation and pvalue is same as computed from
+    scipy."""
+    xs_corr = spearman_r(a, b, "time")
+    xs_p = spearman_r_p_value(a, b, "time")
+    scipy_corr, scipy_p = spearmanr(a, b)
+    assert np.allclose(xs_corr, scipy_corr)
+    assert np.allclose(xs_p, scipy_p)
+
+
+def test_rmse_same_as_sklearn(a, b):
+    """Tests that root mean squared error is same as computed from sklearn."""
+    xs_rmse = rmse(a, b, "time")
+    sklearn_rmse = np.sqrt(mean_squared_error(a, b))
+    assert np.allclose(xs_rmse, sklearn_rmse)
+
+
+def test_mse_same_as_sklearn(a, b):
+    """Tests that mean squared error is same as computed from sklearn."""
+    xs_mse = mse(a, b, "time")
+    sklearn_mse = mean_squared_error(a, b)
+    assert np.allclose(xs_mse, sklearn_mse)
+
+
+def test_mae_same_as_sklearn(a, b):
+    """Tests that mean absolute error is same as computed from sklearn."""
+    xs_mse = mae(a, b, "time")
+    sklearn_mse = mean_absolute_error(a, b)
+    assert np.allclose(xs_mse, sklearn_mse)
+
+
+def test_mape_same_as_numpy(a, b):
+    """Tests that mean absolute percent error is same as computed from numpy."""
+    xs_mape = mape(a, b, "time")
+    np_mape = np.mean(np.abs((a - b) / a))
+    assert np.allclose(xs_mape, np_mape)

--- a/xskillscore/tests/test_np_deterministic.py
+++ b/xskillscore/tests/test_np_deterministic.py
@@ -8,7 +8,7 @@ from sklearn.metrics import (
     median_absolute_error,
 )
 from xskillscore.core.np_deterministic import (
-    _mad,
+    _median_absolute_error,
     _mae,
     _mape,
     _mse,
@@ -261,7 +261,7 @@ def test_mae_nd(a, b):
     assert_allclose(actual, expected)
 
 
-def test_mad_nd(a, b):
+def test_median_absolute_error_nd(a, b):
     axis = 0
     expected = np.squeeze(a[0, :, :]).copy()
     for i in range(np.shape(a)[1]):
@@ -269,7 +269,7 @@ def test_mad_nd(a, b):
             _a = a[:, i, j]
             _b = b[:, i, j]
             expected[i, j] = median_absolute_error(_a, _b)
-    actual = _mad(a, b, axis, skipna)
+    actual = _median_absolute_error(a, b, axis, skipna)
     assert_allclose(actual, expected)
 
     axis = 1
@@ -279,7 +279,7 @@ def test_mad_nd(a, b):
             _a = a[i, :, j]
             _b = b[i, :, j]
             expected[i, j] = median_absolute_error(_a, _b)
-    actual = _mad(a, b, axis, skipna)
+    actual = _median_absolute_error(a, b, axis, skipna)
     assert_allclose(actual, expected)
 
     axis = 2
@@ -289,7 +289,7 @@ def test_mad_nd(a, b):
             _a = a[i, j, :]
             _b = b[i, j, :]
             expected[i, j] = median_absolute_error(_a, _b)
-    actual = _mad(a, b, axis, skipna)
+    actual = _median_absolute_error(a, b, axis, skipna)
     assert_allclose(actual, expected)
 
 

--- a/xskillscore/tests/test_skipna_functionality.py
+++ b/xskillscore/tests/test_skipna_functionality.py
@@ -6,7 +6,7 @@ from xarray.tests import assert_allclose
 
 
 from xskillscore.core.deterministic import (
-    mad,
+    median_absolute_error,
     mae,
     mape,
     mse,
@@ -30,7 +30,7 @@ WEIGHTED_METRICS = [
     rmse,
 ]
 
-NON_WEIGHTED_METRICS = [mad]
+NON_WEIGHTED_METRICS = [median_absolute_error]
 
 
 @pytest.fixture

--- a/xskillscore/tests/test_skipna_functionality.py
+++ b/xskillscore/tests/test_skipna_functionality.py
@@ -54,6 +54,7 @@ def drop_nans(a, b, dim="time"):
     b = b.where(a.notnull())
     return a.dropna(dim), b.dropna(dim)
 
+
 # ADD WEIGHTS
 @pytest.mark.parametrize("metric", METRICS)
 def test_skipna_returns_same_value_as_dropped_pairwise_nans(a, b, metric):

--- a/xskillscore/tests/test_skipna_functionality.py
+++ b/xskillscore/tests/test_skipna_functionality.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from xarray.tests import assert_allclose
+
+
+from xskillscore.core.deterministic import (
+    mad,
+    mae,
+    mape,
+    mse,
+    pearson_r,
+    pearson_r_p_value,
+    rmse,
+    smape,
+    spearman_r,
+    spearman_r_p_value,
+)
+
+METRICS = [
+    pearson_r,
+    pearson_r_p_value,
+    spearman_r,
+    spearman_r_p_value,
+    mae,
+    mse,
+    mad,
+    mape,
+    smape,
+    rmse,
+]
+
+
+@pytest.fixture
+def a():
+    time = pd.date_range("1/1/2000", "1/5/2000", freq="D")
+    da = xr.DataArray([3, np.nan, 5, 7, 9], dims=["time"], coords=[time])
+    return da
+
+
+@pytest.fixture
+def b():
+    time = pd.date_range("1/1/2000", "1/5/2000", freq="D")
+    da = xr.DataArray([7, 2, np.nan, 2, 4], dims=["time"], coords=[time])
+    return da
+
+
+def drop_nans(a, b, dim="time"):
+    """
+    Masks a and b where they have pairwise nans.
+    """
+    a = a.where(b.notnull())
+    b = b.where(a.notnull())
+    return a.dropna(dim), b.dropna(dim)
+
+# ADD WEIGHTS
+@pytest.mark.parametrize("metric", METRICS)
+def test_skipna_returns_same_value_as_dropped_pairwise_nans(a, b, metric):
+    """Tests that DataArrays with pairwise nans return the same result
+    as the same two with those nans dropped."""
+    a_dropped, b_dropped = drop_nans(a, b)
+    res_with_nans = metric(a, b, "time", skipna=True)
+    res_dropped_nans = metric(a_dropped, b_dropped, "time")
+    assert_allclose(res_with_nans, res_dropped_nans)
+
+
+@pytest.mark.parametrize("metric", METRICS)
+def test_skipna_returns_nan_when_false(a, b, metric):
+    """Tests that nan is returned if there's any nans in the time series
+    and skipna is False."""
+    res = metric(a, b, "time", skipna=False)
+    assert np.isnan(res).all()


### PR DESCRIPTION
This PR fixes a bug with `skipna` where accurate results weren't reported if there were pairwise nans, e.g. nans that occurred in differing indices on `a` and `b`. I think this was only occurring with `pearson_r` and `spearman_r`.

The issue in these correlation ones was we would have `np.nanmean(a*b)` for instance, which dealt with nans in the same index. Then we would incorporate `np.nanmean(a*a)` which could bring in values that are actually nans in the `b` array. I hadn't thought of the pairwise issue since I usually work with model output that has nans in all the same places.

* Solves issue by creating nans at every pairwise location.
* Adds testing utilizing below case
* Adds testing for single time series for each metric compared to an outside package.
* Changed the name mad to median_absolute_error per #62. This is actually a median absolute error calculation and mae is already reserved for mean absolute error.
* Added tests to see that results from a gridded product match the same values as if the grid cells were fed in individually. Sometimes you get weird behavior with nans and vectorization, so it's worth the check.


Examples:

**Current master**:
```python
def drop_nans(a, b, dim="time"):
    """
    Masks a and b where they have pairwise nans.
    """
    a = a.where(b.notnull())
    b = b.where(a.notnull())
    return a.dropna(dim), b.dropna(dim)

time = pd.date_range("1/1/2000", "1/5/2000", freq="D")
a = xr.DataArray([3, np.nan, 5, 7, 9], dims=["time"], coords=[time])
b = xr.DataArray([7, 2, np.nan, 2, 4], dims=["time"], coords=[time])
a_dropped, b_dropped = drop_nans(a, b)

xs.pearson_r(a, b, "time", skipna=True)
>>> array(-0.58733524)
xs.pearson_r(a_dropped, b_dropped, "time")
>>> array(-0.73704347)

xs.spearman_r(a, b, "time", skipna=True)
>>> array(-0.42163702)
xs.spearman_r(a_dropped, b_dropped, "time")
>>> array(-0.5)

xs.mae(a, b, "time", skipna=True)
>>> array(4.66666667)
xs.mae(a_dropped, b_dropped, "time")
>>> array(4.66666667)
```

**With PR**:
```python
def drop_nans(a, b, dim="time"):
    """
    Masks a and b where they have pairwise nans.
    """
    a = a.where(b.notnull())
    b = b.where(a.notnull())
    return a.dropna(dim), b.dropna(dim)

time = pd.date_range("1/1/2000", "1/5/2000", freq="D")
a = xr.DataArray([3, np.nan, 5, 7, 9], dims=["time"], coords=[time])
b = xr.DataArray([7, 2, np.nan, 2, 4], dims=["time"], coords=[time])
a_dropped, b_dropped = drop_nans(a, b)

xs.pearson_r(a, b, "time", skipna=True)
>>> array(-0.73704347)
xs.pearson_r(a_dropped, b_dropped, "time")
>>> array(-0.73704347)

xs.spearman_r(a, b, "time", skipna=True)
>>> array(-0.5)
xs.spearman_r(a_dropped, b_dropped, "time")
>>> array(-0.5)

xs.mae(a, b, "time", skipna=True)
>>> array(4.66666667)
xs.mae(a_dropped, b_dropped, "time")
>>> array(4.66666667)
```