### PR TITLE
Add effective p value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog History
 =================
 
+xskillscore v0.0.11 (2020-01-##)
+================================
+
+Features
+--------
+- Add ``effective_sample_size``, ``pearson_r_eff_p_value``, and ``spearman_r_eff_p_value`` for computing statistical significance for temporally correlated data with autocorrelation. `Riley X. Brady`_
+
 xskillscore v0.0.10 (2019-12-21)
 ================================
 

--- a/xskillscore/__init__.py
+++ b/xskillscore/__init__.py
@@ -13,6 +13,7 @@ from .core.deterministic import (
     spearman_r,
     spearman_r_p_value,
     spearman_r_eff_p_value,
+    effective_sample_size,
 )
 from .core.probabilistic import xr_brier_score as brier_score
 from .core.probabilistic import xr_crps_ensemble as crps_ensemble

--- a/xskillscore/__init__.py
+++ b/xskillscore/__init__.py
@@ -7,10 +7,12 @@ from .core.deterministic import (
     mse,
     pearson_r,
     pearson_r_p_value,
+    pearson_r_eff_p_value,
     rmse,
     smape,
     spearman_r,
     spearman_r_p_value,
+    spearman_r_eff_p_value,
 )
 from .core.probabilistic import xr_brier_score as brier_score
 from .core.probabilistic import xr_crps_ensemble as crps_ensemble

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -16,6 +16,7 @@ __all__ = [
     "_mape",
     "_spearman_r",
     "_spearman_r_p_value",
+    "_effective_sample_size",
 ]
 
 
@@ -79,7 +80,7 @@ def __compute_anomalies(a, b, weights, axis, skipna):
     return am, bm
 
 
-def __effective_sample_size(a, b, axis, skipna):
+def _effective_sample_size(a, b, axis, skipna):
     """Effective sample size for temporally correlated data.
 
     .. note::
@@ -262,7 +263,7 @@ def _pearson_r_eff_p_value(a, b, axis, skipna):
     if np.isnan(r).all():
         return r
     else:
-        dof = __effective_sample_size(a, b, axis, skipna) - 2
+        dof = _effective_sample_size(a, b, axis, skipna) - 2
         t_squared = r ** 2 * (dof / ((1.0 - r) * (1.0 + r)))
         _x = dof / (dof + t_squared)
         _x = np.asarray(_x)
@@ -391,7 +392,7 @@ def _spearman_r_eff_p_value(a, b, axis, skipna):
     if skipna:
         a, b, _ = _match_nans(a, b, None)
     rs = _spearman_r(a, b, None, axis, skipna)
-    dof = __effective_sample_size(a, b, axis, skipna) - 2
+    dof = _effective_sample_size(a, b, axis, skipna) - 2
     t = rs * np.sqrt((dof / ((rs + 1.0) * (1.0 - rs))).clip(0))
     p = 2 * distributions.t.sf(np.abs(t), dof)
     return p

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -2,6 +2,8 @@ import bottleneck as bn
 import numpy as np
 from scipy import special
 from scipy.stats import distributions
+import scipy
+
 
 __all__ = [
     "_pearson_r",
@@ -62,6 +64,65 @@ def _check_weights(weights):
         return weights
 
 
+def __compute_anomalies(a, b, weights, axis, skipna):
+    sumfunc, meanfunc = _get_numpy_funcs(skipna)
+    # Only do weighted sums if there are weights. Cannot have a
+    # single generic function with weights of all ones, because
+    # the denominator gets inflated when there are masked regions.
+    if weights is not None:
+        ma = sumfunc(a * weights, axis=axis) / sumfunc(weights, axis=axis)
+        mb = sumfunc(b * weights, axis=axis) / sumfunc(weights, axis=axis)
+    else:
+        ma = meanfunc(a, axis=axis)
+        mb = meanfunc(b, axis=axis)
+    am, bm = a - ma, b - mb
+    return am, bm
+
+
+def __effective_sample_size(a, b, axis, skipna):
+    """Effective sample size for temporally correlated data.
+
+    .. note::
+        This metric should only be applied over the time dimension,
+        since it is designed for temporal autocorrelation.
+    
+    Parameters
+    ----------
+    a : ndarray
+        Input array.
+    b : ndarray
+        Input array.
+    axis : int
+        The axis to compute the effective sample size over.
+    skipna : bool
+        If True, skip NaNs when computing function.
+
+    Returns
+    -------
+    n_eff : ndarray
+        Effective sample size.
+
+    """
+    if skipna:
+        a, b, _ = _match_nans(a, b, None)
+    a = np.rollaxis(a, axis)
+    b = np.rollaxis(b, axis)
+
+    # count total number of samples that are non-nan.
+    n = np.count_nonzero(~np.isnan(a), axis=0)
+
+    # compute lag-1 autocorrelation.
+    am, bm = __compute_anomalies(a, b, weights=None, axis=0, skipna=skipna)
+    a_auto = _pearson_r(am[0:-1], am[1::], weights=None, axis=0, skipna=skipna)
+    b_auto = _pearson_r(bm[0:-1], bm[1::], weights=None, axis=0, skipna=skipna)
+
+    # compute effective sample size per Bretherton et al. 1999
+    n_eff = n * (1 - a_auto * b_auto) / (1 + a_auto * b_auto)
+    n_eff = np.floor(n_eff)
+    n_eff = np.clip(n_eff, 0, n)
+    return n_eff
+
+
 def _pearson_r(a, b, weights, axis, skipna):
     """
     ndarray implementation of scipy.stats.pearsonr.
@@ -95,19 +156,10 @@ def _pearson_r(a, b, weights, axis, skipna):
     weights = _check_weights(weights)
     a = np.rollaxis(a, axis)
     b = np.rollaxis(b, axis)
-
-    # Only do weighted sums if there are weights. Cannot have a
-    # single generic function with weights of all ones, because
-    # the denominator gets inflated when there are masked regions.
     if weights is not None:
         weights = np.rollaxis(weights, axis)
-        ma = sumfunc(a * weights, axis=0) / sumfunc(weights, axis=0)
-        mb = sumfunc(b * weights, axis=0) / sumfunc(weights, axis=0)
-    else:
-        ma = meanfunc(a, axis=0)
-        mb = meanfunc(b, axis=0)
 
-    am, bm = a - ma, b - mb
+    am, bm = __compute_anomalies(a, b, weights=weights, axis=0, skipna=skipna)
 
     if weights is not None:
         r_num = sumfunc(weights * am * bm, axis=0)
@@ -134,7 +186,7 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
     b : ndarray
         Input array.
     axis : int
-        The axis to apply the correlation along.
+        The axis to apply the compute the p value over.
     weights : ndarray
         Input array of weights for a and b.
     skipna : bool
@@ -161,6 +213,56 @@ def _pearson_r_p_value(a, b, weights, axis, skipna):
         b = np.rollaxis(b, axis)
         # count non-nans
         dof = np.count_nonzero(~np.isnan(a), axis=0) - 2
+        t_squared = r ** 2 * (dof / ((1.0 - r) * (1.0 + r)))
+        _x = dof / (dof + t_squared)
+        _x = np.asarray(_x)
+        _x = np.where(_x < 1.0, _x, 1.0)
+        _a = 0.5 * dof
+        _b = 0.5
+        res = special.betainc(_a, _b, _x)
+        # reset masked values to nan
+        nan_locs = np.where(np.isnan(r))
+        if len(nan_locs[0]) > 0:
+            res[nan_locs] = np.nan
+        return res
+
+
+def _pearson_r_eff_p_value(a, b, axis, skipna):
+    """Pearson r p value accounting for autocorrelation.
+
+    .. note::
+        This metric should only be applied over the time dimension,
+        since it is designed for temporal autocorrelation.
+
+    Parameters
+    ----------
+    a : ndarray
+        Input array.
+    b : ndarray
+        Input array.
+    axis : int
+        The axis to compute the p value over.
+    skipna : bool
+        If True, skip NaNs when computing function.
+
+    Returns
+    -------
+    res : ndarray
+        2-tailed p-value.
+    
+    Reference
+    ---------
+    * Bretherton, Christopher S., et al. "The effective number of spatial degrees of
+      freedom of a time-varying field." Journal of climate 12.7 (1999): 1990-2009.
+
+    """
+    if skipna:
+        a, b, _ = _match_nans(a, b, None)
+    r = _pearson_r(a, b, None, axis, skipna)
+    if np.isnan(r).all():
+        return r
+    else:
+        dof = __effective_sample_size(a, b, axis, skipna) - 2
         t_squared = r ** 2 * (dof / ((1.0 - r) * (1.0 + r)))
         _x = dof / (dof + t_squared)
         _x = np.asarray(_x)
@@ -248,6 +350,48 @@ def _spearman_r_p_value(a, b, weights, axis, skipna):
     b = np.rollaxis(b, axis)
     # count non-nans
     dof = np.count_nonzero(~np.isnan(a), axis=0) - 2
+    t = rs * np.sqrt((dof / ((rs + 1.0) * (1.0 - rs))).clip(0))
+    p = 2 * distributions.t.sf(np.abs(t), dof)
+    return p
+
+
+def _spearman_r_eff_p_value(a, b, axis, skipna):
+    """Spearman rank correlation p value, accounting for autocorrelation.
+
+    .. note::
+        This metric should only be applied over the time dimension,
+        since it is designed for temporal autocorrelation.
+
+    Parameters
+    ----------
+    a : ndarray
+        Input array.
+    b : ndarray
+        Input array.
+    weights : ndarray
+        Input array.
+    skipna : bool
+        If True, skip NaNs when computing function.
+
+    Returns
+    -------
+    res : ndarray
+        2-tailed p-value.
+
+    See Also
+    --------
+    scipy.stats.spearmanr
+
+    Reference
+    ---------
+    * Bretherton, Christopher S., et al. "The effective number of spatial degrees of
+      freedom of a time-varying field." Journal of climate 12.7 (1999): 1990-2009.
+
+    """
+    if skipna:
+        a, b, _ = _match_nans(a, b, None)
+    rs = _spearman_r(a, b, None, axis, skipna)
+    dof = __effective_sample_size(a, b, axis, skipna) - 2
     t = rs * np.sqrt((dof / ((rs + 1.0) * (1.0 - rs))).clip(0))
     p = 2 * distributions.t.sf(np.abs(t), dof)
     return p

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -2,7 +2,6 @@ import bottleneck as bn
 import numpy as np
 from scipy import special
 from scipy.stats import distributions
-import scipy
 
 
 __all__ = [
@@ -85,8 +84,10 @@ def _effective_sample_size(a, b, axis, skipna):
 
     .. note::
         This metric should only be applied over the time dimension,
-        since it is designed for temporal autocorrelation.
-    
+        since it is designed for temporal autocorrelation. Weights
+        are not included due to the reliance on temporal
+        autocorrelation.
+
     Parameters
     ----------
     a : ndarray
@@ -102,6 +103,13 @@ def _effective_sample_size(a, b, axis, skipna):
     -------
     n_eff : ndarray
         Effective sample size.
+
+    Reference
+    ---------
+    * Bretherton, Christopher S., et al. "The effective number of spatial degrees of
+      freedom of a time-varying field." Journal of climate 12.7 (1999): 1990-2009.
+    * Wilks, Daniel S. Statistical methods in the atmospheric sciences. Vol. 100.
+      Academic press, 2011.
 
     """
     if skipna:
@@ -233,7 +241,9 @@ def _pearson_r_eff_p_value(a, b, axis, skipna):
 
     .. note::
         This metric should only be applied over the time dimension,
-        since it is designed for temporal autocorrelation.
+        since it is designed for temporal autocorrelation. Weights
+        are not included due to the reliance on temporal
+        autocorrelation.
 
     Parameters
     ----------
@@ -250,11 +260,13 @@ def _pearson_r_eff_p_value(a, b, axis, skipna):
     -------
     res : ndarray
         2-tailed p-value.
-    
+
     Reference
     ---------
     * Bretherton, Christopher S., et al. "The effective number of spatial degrees of
       freedom of a time-varying field." Journal of climate 12.7 (1999): 1990-2009.
+    * Wilks, Daniel S. Statistical methods in the atmospheric sciences. Vol. 100.
+      Academic press, 2011.
 
     """
     if skipna:
@@ -361,7 +373,9 @@ def _spearman_r_eff_p_value(a, b, axis, skipna):
 
     .. note::
         This metric should only be applied over the time dimension,
-        since it is designed for temporal autocorrelation.
+        since it is designed for temporal autocorrelation. Weights
+        are not included due to the reliance on temporal
+        autocorrelation.
 
     Parameters
     ----------
@@ -387,6 +401,8 @@ def _spearman_r_eff_p_value(a, b, axis, skipna):
     ---------
     * Bretherton, Christopher S., et al. "The effective number of spatial degrees of
       freedom of a time-varying field." Journal of climate 12.7 (1999): 1990-2009.
+    * Wilks, Daniel S. Statistical methods in the atmospheric sciences. Vol. 100.
+      Academic press, 2011.
 
     """
     if skipna:

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -19,6 +19,7 @@ from xskillscore.core.deterministic import (
     spearman_r,
     spearman_r_p_value,
     spearman_r_eff_p_value,
+    effective_sample_size,
 )
 from xskillscore.core.np_deterministic import (
     _median_absolute_error,
@@ -33,6 +34,7 @@ from xskillscore.core.np_deterministic import (
     _spearman_r,
     _spearman_r_p_value,
     _spearman_r_eff_p_value,
+    _effective_sample_size,
 )
 
 correlation_metrics = [
@@ -42,6 +44,7 @@ correlation_metrics = [
     (spearman_r, _spearman_r),
     (spearman_r_p_value, _spearman_r_p_value),
     (spearman_r_eff_p_value, _spearman_r_eff_p_value),
+    (effective_sample_size, _effective_sample_size),
 ]
 distance_metrics = [
     (mse, _mse),
@@ -132,7 +135,7 @@ def test_correlation_metrics_xr(a, b, dim, weight_bool, weights, metrics):
     # Generates subsetted weights to pass in as arg to main function and for
     # the numpy testing.
     _weights = adjust_weights(dim, weight_bool, weights)
-    if metric in [pearson_r_eff_p_value, spearman_r_eff_p_value]:
+    if metric in [pearson_r_eff_p_value, spearman_r_eff_p_value, effective_sample_size]:
         actual = metric(a, b, dim)
     else:
         actual = metric(a, b, dim, weights=_weights)
@@ -153,7 +156,7 @@ def test_correlation_metrics_xr(a, b, dim, weight_bool, weights, metrics):
     _weights = _preprocess_weights(_a, dim, new_dim, _weights)
 
     axis = _a.dims.index(new_dim)
-    if metric in [pearson_r_eff_p_value, spearman_r_eff_p_value]:
+    if metric in [pearson_r_eff_p_value, spearman_r_eff_p_value, effective_sample_size]:
         res = _metric(_a.values, _b.values, axis, skipna=False)
     else:
         res = _metric(_a.values, _b.values, _weights.values, axis, skipna=False)
@@ -212,7 +215,7 @@ def test_correlation_metrics_xr_dask(
     # the numpy testing.
     _weights = adjust_weights(dim, weight_bool, weights)
     
-    if metric in [pearson_r_eff_p_value, spearman_r_eff_p_value]:
+    if metric in [pearson_r_eff_p_value, spearman_r_eff_p_value, effective_sample_size]:
         actual = metric(a, b, dim)
     else:
         actual = metric(a, b, dim, weights=_weights)
@@ -222,7 +225,7 @@ def test_correlation_metrics_xr_dask(
     if _weights is not None:
         _weights = _weights.load()
     
-    if metric in [pearson_r_eff_p_value, spearman_r_eff_p_value]:
+    if metric in [pearson_r_eff_p_value, spearman_r_eff_p_value, effective_sample_size]:
         expected = metric(a.load(), b.load(), dim)
     else:
         expected = metric(a.load(), b.load(), dim, _weights)

--- a/xskillscore/tests/test_effective_p_value.py
+++ b/xskillscore/tests/test_effective_p_value.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from xskillscore.core.deterministic import (
+    pearson_r_p_value,
+    pearson_r_eff_p_value,
+    spearman_r_p_value,
+    spearman_r_eff_p_value,
+    effective_sample_size,
+)
+
+DIM = "time"
+
+
+@pytest.fixture
+def a():
+    times = pd.date_range("1/1/2000", "2/3/2000", freq="D")
+    lats = np.arange(4)
+    lons = np.arange(5)
+    data = np.random.rand(len(times), len(lats), len(lons))
+    return xr.DataArray(data, coords=[times, lats, lons], dims=["time", "lat", "lon"])
+
+
+@pytest.fixture
+def b(a):
+    b = a.copy()
+    b.values = np.random.rand(a.shape[0], a.shape[1], a.shape[2])
+    return b
+
+
+def test_eff_sample_size_smaller_than_n(a, b):
+    """Tests that the effective sample size is less than or equal to the normal
+    sample size."""
+    # Can just use `.size` here since we don't
+    # have any NaNs in the test.
+    N = a[DIM].size
+    eff_N = effective_sample_size(a, b, DIM)
+    assert (eff_N <= N).all()
+
+
+def test_eff_pearson_p_greater_or_equal_to_normal_p(a, b):
+    """Tests that the effective Pearson p value is greater than or equal to the
+    normal Pearson p value."""
+    normal_p = pearson_r_p_value(a, b, "time")
+    eff_p = pearson_r_eff_p_value(a, b, "time")
+    assert (eff_p >= normal_p).all()
+
+
+def test_eff_spearman_p_greater_or_equal_to_normal_p(a, b):
+    """Tests that the effective Spearman p value is greater than or equal to the
+    normal Spearman p value."""
+    normal_p = spearman_r_p_value(a, b, "time")
+    eff_p = spearman_r_eff_p_value(a, b, "time")
+    assert (eff_p >= normal_p).all()


### PR DESCRIPTION
This PR adds the "effective" p value for temporal autocorrelation, per section 5, equation 31 of Bretherton, Christopher S., et al. "The effective number of spatial degrees of freedom of a time-varying field." Journal of climate 12.7 (1999): 1990-2009. 

This is an important metric to include in geosciences where there tends to be a lot of temporal autocorrelation in time series, which artificially inflates correlation significance. 

This does not address spatial autocorrelation per e.g. Wilks, Daniels. "The stippling shows statistically significant grid points”: How research results are routinely overstated and overinterpreted, and what to do about it." Bulletin of the American Meteorological Society 97.12 (2016): 2263-2273. And I believe this is also addressed in the Bretherton paper. I don't have time right now to read through and implement these, but it would be important to think about in the future.

Let me know @raybellwaves if this is appropriate here. I was implementing it manually in `climpred` and figured it's a pretty standard thing for temporal p values that could be implemented in `xskillscore` instead.

CC @aaronspring 