### PR TITLE
fix read only bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Internal Changes
 - Add ``black``, ``flake8``, ``isort``, ``doc8`` and ``pre-commit`` for formatting
   similar to ``climpred``. `Aaron Spring`_ and `Ray Bell`_
 
+Bug Fixes
+---------
+- Avoid mutating inputted arrays when `skipna=True`. (:pr:`111`) `Riley X. Brady`_.
+- Avoid read-only error that appeared due to not copying input arrays when dealing
+  with NaNs. (:pr:`111`) `Riley X. Brady`_.
+
 
 xskillscore v0.0.15 (2020-03-24)
 ================================

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -62,7 +62,7 @@ def _check_weights(weights):
     if weights is None:
         return None
     # catch if np.ndarray values are None
-    elif (weights is None).all():
+    elif (weights == None).all():
         return None
     elif np.all(np.isnan(weights)):
         return None

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -32,6 +32,8 @@ def _match_nans(a, b, weights):
         pairwise locations.
     """
     if np.isnan(a).any() or np.isnan(b).any():
+        # Avoids mutating original arrays and bypasses read-only issue.
+        a, b = a.copy(), b.copy()
         # Find pairwise indices in a and b that have nans.
         idx = np.logical_or(np.isnan(a), np.isnan(b))
         a[idx], b[idx] = np.nan, np.nan
@@ -60,7 +62,7 @@ def _check_weights(weights):
     if weights is None:
         return None
     # catch if np.ndarray values are None
-    elif (weights == None).all():
+    elif (weights is None).all():
         return None
     elif np.all(np.isnan(weights)):
         return None


### PR DESCRIPTION
# Description

Fixes bug that returns error that arrays are read-only. Also avoids mutating the original arrays that were submitted when `skipna=True`.

Closes https://github.com/raybellwaves/xskillscore/issues/109

## Type of change

Please delete options that are not relevant.

-   [X]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I'm not sure how to test this yet. I've only replicated it in cases where `vectorize=True` on `xr.apply_ufunc`. So I'm not sure if @ahuang11 can replicate #109 so we can add it to testing. Regardless, this is a good addition to avoid mutating the original arrays `a` and `b` and it should also fix the read only bug.

## Checklist (while developing)

-   [X]  I have commented my code, particularly in hard-to-understand areas
-   [ ]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [X]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [X]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.
