### PR TITLE
lock black version

### DIFF
--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -24,7 +24,7 @@ dependencies:
   - xhistogram
   # Package Management
   - asv
-  - black
+  - black==19.10b0
   - coveralls
   - doc8
   - importlib_metadata


### PR DESCRIPTION
Locks the version of `black` to `19.10b0` to deal with bug with `dataclasses` module in new release. We could force install of `dataclasses` in our dev environment, but `black` then also struggles with the string-normalization flag which deals with `"` vs. `'` and becomes a headache. We can switch back to the newest `black` releases once they address some of this.