### PR TITLE
Automatically determine version in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,8 +23,7 @@ else:
     print('pip environment:')
     subprocess.run(['pip', 'list'])
 
-# TODO add back in after release
-# print("xskillscore: %s, %s" % (xskillscore.__version__, xskillscore.__file__))
+print('xskillscore: %s, %s' % (xskillscore.__version__, xskillscore.__file__))
 
 
 # -- General configuration ---------------------------------------------------
@@ -76,9 +75,7 @@ project = 'xskillscore'
 copyright = '2018-%s, xskillscore Developers' % datetime.datetime.now().year
 
 # The full version, including alpha/beta/rc tags
-# TODO add back in after release
-# version = xskillscore.__version__
-version = '0.0.17'
+version = xskillscore.__version__
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
# Description

Use `xskillscore.__version__` to determine version for docs rendering.

Closes https://github.com/raybellwaves/xskillscore/issues/146
