### PR TITLE
weights input_core_dims [] instead of [None]

### DIFF
--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -20,7 +20,7 @@ dependencies:
   - properscoring
   - scikit-learn
   - scipy
-  - xarray
+  - xarray>=0.16.1
   - xhistogram
   # Package Management
   - asv

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy
 properscoring
 scikit-learn
 scipy
-xarray
+xarray>=0.16.1
 xhistogram

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -63,7 +63,7 @@ def _determine_input_core_dims(dim, weights):
         dim = [dim]
     # build input_core_dims depending on weights
     if weights is None:
-        input_core_dims = [dim, dim, [None]]
+        input_core_dims = [dim, dim, []]
     else:
         input_core_dims = [dim, dim, dim]
     return input_core_dims


### PR DESCRIPTION
# Description

broke with xr0.16.1 where xr.0.16.0 was fine. problem was input_core_dims in xr.apply_ufunc.
fixed xr version to larger than xr0.16.1 in requirements and ci/env

Closes #183 

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

Please add any references to manuscripts, textbooks, etc.
